### PR TITLE
Fix: Configurar bot para usar polling correctamente en Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: python heroku_app.py
+worker: python heroku_app.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ google-auth-oauthlib==1.0.0
 pandas==2.0.0
 pytz==2023.3
 tornado==6.3.3
+requests==2.31.0


### PR DESCRIPTION
## Problema
El bot está configurado para usar webhooks en Heroku, pero esto está causando un conflicto con el método de polling que se está intentando utilizar actualmente. Esto resulta en el siguiente error:

```
telegram.error.Conflict: Conflict: can't use getUpdates method while webhook is active; use deleteWebhook to delete the webhook first
```

## Solución
Este PR cambia la configuración del bot para usar polling de manera correcta en Heroku:

1. **Modificaciones en heroku_app.py**:
   - Eliminación del código relacionado con webhooks
   - Implementación de una función para eliminar cualquier webhook existente
   - Configuración del bot para utilizar polling (usando `application.run_polling()`)
   - Mejora del manejo de errores y logging

2. **Actualización del Procfile**:
   - Cambio de `web: python heroku_app.py` a `worker: python heroku_app.py`
   - Esto es crucial ya que los bots con polling deben ejecutarse como dynos worker, no web

3. **Actualización de requirements.txt**:
   - Agregada la biblioteca `requests` necesaria para la funcionalidad de eliminación de webhook

## Instrucciones para desplegar
Después de fusionar este PR, se deben seguir estos pasos en Heroku:

1. Escalar los dynos correctamente:
   ```
   heroku ps:scale web=0 worker=1
   ```

2. Asegurarse de que la variable de entorno TELEGRAM_BOT_TOKEN esté configurada:
   ```
   heroku config:get TELEGRAM_BOT_TOKEN
   ```

3. Reiniciar la aplicación:
   ```
   heroku ps:restart
   ```

4. Verificar los logs para asegurarse de que todo funcione correctamente:
   ```
   heroku logs --tail
   ```