### PR TITLE
Mejorar solicitud de kg en compra con adelanto

### DIFF
--- a/handlers/compra_adelanto.py
+++ b/handlers/compra_adelanto.py
@@ -135,10 +135,11 @@ async def seleccionar_proveedor_callback(update: Update, context: ContextTypes.D
         context.user_data['saldo_adelanto'] = saldo_total
         context.user_data['adelantos_proveedor'] = datos_proveedor['adelantos']
         
-        # Mostrar mensaje simplificado y solicitar la cantidad de café directamente
+        # Mostrar mensaje de proveedor seleccionado y solicitar la cantidad de café
         await query.edit_message_text(
-            f"👨‍🌾 Proveedor: {proveedor} - {format_currency(saldo_total)}\n\n"
-            f"¿Cuántos kilogramos de café estás comprando?"
+            f"👨‍🌾 Proveedor seleccionado: {proveedor}\n"
+            f"💰 Saldo disponible: {format_currency(saldo_total)}\n\n"
+            f"Ahora, ingresa la cantidad de café en kg:"
         )
         
         return CANTIDAD


### PR DESCRIPTION
## Descripción del cambio

Este PR soluciona el problema en la funcionalidad `/compra_adelanto` para que solicite explícitamente la cantidad de kilogramos al usuario, de manera similar a como lo hace la compra normal.

## Cambios realizados

- Mejorado el texto en la función `seleccionar_proveedor_callback` para mostrar claramente:
  - El proveedor seleccionado
  - El saldo disponible
  - Una solicitud explícita de la cantidad de café en kg

## Cómo probar

1. Iniciar el bot
2. Ejecutar el comando `/compra_adelanto`
3. Seleccionar un proveedor de la lista
4. Verificar que el bot solicita adecuadamente la cantidad de kilogramos

## Capturas de pantalla
Antes: El mensaje no era tan claro sobre la solicitud de kg.
Después: El mensaje ahora dice claramente "Ahora, ingresa la cantidad de café en kg:"