### PR TITLE
Reordenar lista de comandos en la ayuda

### DIFF
--- a/handlers/start.py
+++ b/handlers/start.py
@@ -17,15 +17,15 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     await update.message.reply_text(
         "🤖 *Comandos disponibles* 🤖\n\n"
         "*/compra* - Registrar una nueva compra de café\n"
-        "*/proceso* - Registrar procesamiento de café\n"
+        "*/compra_adelanto* - Compra con adelanto\n"
         "*/gasto* - Registrar gastos\n"
+        "*/adelanto* - Registrar adelanto a proveedor\n"
+        "*/proceso* - Registrar procesamiento de café\n"
         "*/venta* - Registrar una venta\n"
         "*/reporte* - Ver reportes y estadísticas\n"
         "*/pedido* - Registrar pedido de cliente\n"
         "*/pedidos* - Ver pedidos pendientes\n"
-        "*/adelanto* - Registrar adelanto a proveedor\n"
         "*/adelantos* - Ver adelantos vigentes\n"
-        "*/compra_adelanto* - Compra con adelanto\n"
         "*/ayuda* - Ver esta ayuda\n\n"
         "Para más información, consulta la documentación completa.",
         parse_mode="Markdown"


### PR DESCRIPTION
## Descripción

Este PR reorganiza el orden de los comandos mostrados en la ayuda del bot (`/ayuda` y `/help`) según las prioridades de uso:

1. `/compra` - Como primera opción
2. `/compra_adelanto` - Como segunda opción
3. `/gasto` - Como tercera opción 
4. `/adelanto` - Como cuarta opción

Los demás comandos mantienen su orden relativo original.

## Detalles

- El cambio solo afecta al orden visual de los comandos en el mensaje de ayuda
- No altera ninguna funcionalidad ni comportamiento del bot
- Mejora la experiencia del usuario al poner primero los comandos más usados

## Cómo probar

1. Enviar `/ayuda` o `/help` al bot
2. Verificar que los comandos aparecen en el orden solicitado:
   - `/compra`
   - `/compra_adelanto`
   - `/gasto`
   - `/adelanto`
   - Seguidos por el resto de los comandos