### PR TITLE
Añadir soporte para la hoja de adelantos en la integración con Google Sheets

### DIFF
--- a/utils/sheets.py
+++ b/utils/sheets.py
@@ -12,7 +12,8 @@ SHEET_IDS = {
     'compras': 0,  # Los ids son índices (0 para la primera hoja, 1 para la segunda, etc.)
     'proceso': 1,
     'gastos': 2,
-    'ventas': 3
+    'ventas': 3,
+    'adelantos': 4  # Añadimos la hoja de adelantos con índice 4
 }
 
 # Cabeceras para cada hoja
@@ -20,7 +21,8 @@ HEADERS = {
     'compras': ['fecha', 'tipo_cafe', 'proveedor', 'cantidad', 'precio', 'total'],
     'proceso': ['fecha', 'lote', 'estado', 'cantidad', 'notas'],
     'gastos': ['fecha', 'concepto', 'monto', 'categoria', 'notas'],
-    'ventas': ['fecha', 'cliente', 'producto', 'cantidad', 'precio', 'total']
+    'ventas': ['fecha', 'cliente', 'producto', 'cantidad', 'precio', 'total'],
+    'adelantos': ['fecha', 'hora', 'proveedor', 'monto', 'saldo_restante', 'notas', 'registrado_por']  # Añadimos cabeceras para adelantos
 }
 
 def get_credentials():


### PR DESCRIPTION
## Descripción
Este PR arregla el error que ocurre al utilizar el comando `/adelanto`. El problema se debía a que la hoja "adelantos" no estaba registrada en el módulo `sheets.py`, lo que causaba el siguiente error:

```
Nombre de hoja inválido: adelantos
```

## Cambios realizados
- Añadí "adelantos" al diccionario SHEET_IDS con el índice 4
- Añadí las cabeceras correspondientes al diccionario HEADERS utilizando el formato definido en adelantos.py

## Pruebas realizadas
Tras este cambio, el comando `/adelanto` debería funcionar correctamente permitiendo:
- Registrar adelantos a proveedores
- Visualizar adelantos existentes
- Gestionar saldos de adelantos

## Nota
Asegúrate de que en Google Sheets exista una hoja llamada "adelantos" (en la posición 5, ya que los índices empiezan en 0). Si no existe, deberás crearla manualmente o el sistema intentará crearla automáticamente.

Fixes: Error "Nombre de hoja inválido: adelantos" al registrar adelantos