### PR TITLE
Corrige el problema de las fechas que se muestran como números en la hoja de compras

### DIFF
--- a/handlers/compras.py
+++ b/handlers/compras.py
@@ -176,9 +176,9 @@ async def confirmar(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
         # Preparar datos para guardar
         compra = datos_compra[user_id].copy()
         
-        # Añadir fecha actualizada
+        # Añadir fecha actualizada - CORREGIDO: Formato de fecha cambiado para coincidir con el formato esperado
         now = get_now_peru()
-        compra["fecha"] = now.strftime("%Y-%m-%d %H:%M:%S")
+        compra["fecha"] = now.strftime("%Y-%m-%d %H:%M")
         
         # Verificar que todos los datos requeridos estén presentes
         campos_requeridos = ["tipo_cafe", "proveedor", "cantidad", "precio", "total", "fase_actual", "kg_disponibles"]

--- a/handlers/compras.py
+++ b/handlers/compras.py
@@ -4,7 +4,7 @@ from telegram import Update, ReplyKeyboardMarkup, ReplyKeyboardRemove
 from telegram.ext import CommandHandler, ConversationHandler, MessageHandler, filters, ContextTypes
 from config import COMPRAS_FILE
 from utils.db import append_data
-from utils.helpers import get_now_peru, safe_float
+from utils.helpers import get_now_peru, safe_float, format_date_for_sheets
 
 # Configurar logging
 logger = logging.getLogger(__name__)
@@ -176,9 +176,10 @@ async def confirmar(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
         # Preparar datos para guardar
         compra = datos_compra[user_id].copy()
         
-        # Añadir fecha actualizada - CORREGIDO: Formato de fecha cambiado para coincidir con el formato esperado
+        # Añadir fecha actualizada con formato protegido para Google Sheets
         now = get_now_peru()
-        compra["fecha"] = now.strftime("%Y-%m-%d %H:%M")
+        fecha_formateada = now.strftime("%Y-%m-%d %H:%M")
+        compra["fecha"] = format_date_for_sheets(fecha_formateada)
         
         # Verificar que todos los datos requeridos estén presentes
         campos_requeridos = ["tipo_cafe", "proveedor", "cantidad", "precio", "total", "fase_actual", "kg_disponibles"]

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -11,6 +11,22 @@ def get_now_peru():
     peru_tz = pytz.timezone('America/Lima')
     return datetime.datetime.now(peru_tz)
 
+def format_date_for_sheets(date_string):
+    """
+    Formatea una cadena de fecha para evitar la conversión automática en Google Sheets.
+    
+    Args:
+        date_string: Cadena de texto con la fecha
+        
+    Returns:
+        str: Fecha con un apóstrofe al inicio para forzar el formato de texto en Google Sheets
+    """
+    if not date_string:
+        return ""
+    
+    # Añadir un apóstrofe al inicio para forzar el formato de texto en Google Sheets
+    return f"'{date_string}"
+
 def format_currency(amount, symbol="S/"):
     """Formatea un valor como moneda"""
     if not amount:


### PR DESCRIPTION
## Descripción del Problema
Se identificó un problema con el formato de fecha en el comando de compra. Las fechas se mostraban como números (45795.04447) en lugar del formato legible esperado (2025-05-08 13:14) en la hoja de cálculo de Google Sheets.

## Solución
He implementado una solución completa para corregir este problema:

1. **Prevención para nuevos registros:**
   - Creé una nueva función `format_date_for_sheets` en `utils/helpers.py` que añade una comilla simple (`'`) al inicio de las cadenas de fecha, lo que evita la conversión automática en Google Sheets
   - Actualicé el handler de compras para usar esta función antes de guardar los datos
   - Además, se eliminaron los segundos del formato de fecha para mantener consistencia con los datos existentes

## Detalles Técnicos
La comilla simple al principio (`'`) hace que Google Sheets trate la cadena como texto en lugar de intentar convertirla automáticamente a un formato de fecha numérico. Esta es una práctica común para prevenir la conversión automática en hojas de cálculo.

## Test
He probado manualmente la solución y confirmo que las fechas ahora se guardan correctamente en formato texto, manteniendo el formato legible "YYYY-MM-DD HH:MM".

## Notas Adicionales
Esta corrección garantiza que las fechas en las nuevas compras sean consistentes y legibles en la hoja de cálculo, facilitando la gestión y el análisis de los datos.