### PR TITLE
Corregir orden de columnas: registrado_por antes de preciototal

### DIFF
--- a/handlers/compras.py
+++ b/handlers/compras.py
@@ -16,8 +16,8 @@ TIPO_CAFE, PROVEEDOR, CANTIDAD, PRECIO, CONFIRMAR = range(5)
 # Datos temporales
 datos_compra = {}
 
-# Headers para la hoja de compras - restructuración: id, fecha, tipo_cafe, proveedor, cantidad, precio, preciototal, notas, registrado_por
-COMPRAS_HEADERS = ["id", "fecha", "tipo_cafe", "proveedor", "cantidad", "precio", "preciototal", "notas", "registrado_por"]
+# Headers para la hoja de compras - restructuración: id, fecha, tipo_cafe, proveedor, cantidad, precio, registrado_por, preciototal, notas
+COMPRAS_HEADERS = ["id", "fecha", "tipo_cafe", "proveedor", "cantidad", "precio", "registrado_por", "preciototal", "notas"]
 
 # Tipos de café predefinidos - solo 3 opciones fijas
 TIPOS_CAFE = ["CEREZO", "MOTE", "PERGAMINO"]
@@ -217,9 +217,9 @@ async def confirmar(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
                 "proveedor": compra.get("proveedor", ""),
                 "cantidad": compra.get("cantidad", ""),
                 "precio": compra.get("precio", ""),
+                "registrado_por": compra.get("registrado_por", ""),
                 "preciototal": compra.get("preciototal", ""),
-                "notas": compra.get("notas", ""),
-                "registrado_por": compra.get("registrado_por", "")
+                "notas": compra.get("notas", "")
             }
             
             # Usar append_sheets directamente

--- a/utils/sheets.py
+++ b/utils/sheets.py
@@ -26,7 +26,7 @@ TRANSICIONES_PERMITIDAS = {
 
 # Cabeceras para las hojas
 HEADERS = {
-    "compras": ["id", "fecha", "tipo_cafe", "proveedor", "cantidad", "precio", "preciototal", "notas", "registrado_por"],
+    "compras": ["id", "fecha", "tipo_cafe", "proveedor", "cantidad", "precio", "registrado_por", "preciototal", "notas"],
     "proceso": ["fecha", "origen", "destino", "cantidad", "compras_ids", "merma", "notas", "registrado_por"],
     "gastos": ["fecha", "categoria", "monto", "descripcion", "registrado_por"],
     "ventas": ["fecha", "cliente", "tipo_cafe", "peso", "precio_kg", "total", "notas", "registrado_por"],


### PR DESCRIPTION
## Corrección del orden de columnas en la tabla de compras

### Problema encontrado
En la tabla de compras, el campo `registrado_por` estaba apareciendo después del campo `total` cuando debería estar antes. Esto causaba una inconsistencia en la visualización de los datos.

### Cambios realizados

1. **En `utils/sheets.py`**:
   - Se ha modificado la definición de `HEADERS` para la tabla "compras", cambiando el orden de las columnas para que `registrado_por` aparezca antes de `preciototal`.
   - El nuevo orden es: `["id", "fecha", "tipo_cafe", "proveedor", "cantidad", "precio", "registrado_por", "preciototal", "notas"]`

2. **En `handlers/compras.py`**:
   - Se actualizó la definición de `COMPRAS_HEADERS` para mantener la consistencia con los cambios en `sheets.py`.
   - Se actualizó la función `confirmar` para asegurar que los datos se envíen en el mismo orden que las cabeceras.

### Beneficios
- Mejora la visualización de los datos en la hoja de cálculo
- Mantiene una estructura lógica donde el usuario que registra la compra aparece antes del total calculado
- Asegura la consistencia entre la definición de las columnas y el orden de inserción de datos

### Pruebas realizadas
- Se ha verificado que al ejecutar el comando `/compra`, los datos se guarden correctamente con el nuevo orden de columnas.
- Se ha confirmado que el campo `registrado_por` aparece ahora antes del campo `preciototal`.