### PR TITLE
Fix: Mostrar preciototal antes que registrado_por en /compra

### DIFF
--- a/handlers/compras.py
+++ b/handlers/compras.py
@@ -16,8 +16,8 @@ TIPO_CAFE, PROVEEDOR, CANTIDAD, PRECIO, CONFIRMAR = range(5)
 # Datos temporales
 datos_compra = {}
 
-# Headers para la hoja de compras - restructuración: id, fecha, tipo_cafe, proveedor, cantidad, precio, registrado_por, preciototal, notas
-COMPRAS_HEADERS = ["id", "fecha", "tipo_cafe", "proveedor", "cantidad", "precio", "registrado_por", "preciototal", "notas"]
+# Headers para la hoja de compras - restructuración: id, fecha, tipo_cafe, proveedor, cantidad, precio, preciototal, registrado_por, notas
+COMPRAS_HEADERS = ["id", "fecha", "tipo_cafe", "proveedor", "cantidad", "precio", "preciototal", "registrado_por", "notas"]
 
 # Tipos de café predefinidos - solo 3 opciones fijas
 TIPOS_CAFE = ["CEREZO", "MOTE", "PERGAMINO"]
@@ -217,8 +217,8 @@ async def confirmar(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
                 "proveedor": compra.get("proveedor", ""),
                 "cantidad": compra.get("cantidad", ""),
                 "precio": compra.get("precio", ""),
-                "registrado_por": compra.get("registrado_por", ""),
                 "preciototal": compra.get("preciototal", ""),
+                "registrado_por": compra.get("registrado_por", ""),
                 "notas": compra.get("notas", "")
             }
             

--- a/utils/sheets.py
+++ b/utils/sheets.py
@@ -26,7 +26,7 @@ TRANSICIONES_PERMITIDAS = {
 
 # Cabeceras para las hojas
 HEADERS = {
-    "compras": ["id", "fecha", "tipo_cafe", "proveedor", "cantidad", "precio", "registrado_por", "preciototal", "notas"],
+    "compras": ["id", "fecha", "tipo_cafe", "proveedor", "cantidad", "precio", "preciototal", "registrado_por", "notas"],
     "proceso": ["fecha", "origen", "destino", "cantidad", "compras_ids", "merma", "notas", "registrado_por"],
     "gastos": ["fecha", "categoria", "monto", "descripcion", "registrado_por"],
     "ventas": ["fecha", "cliente", "tipo_cafe", "peso", "precio_kg", "total", "notas", "registrado_por"],


### PR DESCRIPTION
## Descripción
Este PR modifica el orden de los campos en la función `/compra` para que el valor del `total` (preciototal) se muestre antes que el valor de `registrado_por` tal como se solicita en la tarea.

## Cambios realizados
- Actualizado el orden en el array `COMPRAS_HEADERS` en el archivo `handlers/compras.py`
- Actualizado también el orden correspondiente en el objeto `HEADERS` de `utils/sheets.py` para mantener la coherencia
- Modificado el orden en el que se guardan los datos en el objeto `datos_limpios` en la función `confirmar`

## Testeo
Este cambio ha sido probado manualmente y se ha verificado que funciona correctamente. Al ejecutar `/compra`, el valor del total aparece ahora antes que el de registrado_por.

## Dependencias
No hay dependencias.