### PR TITLE
Update coffee phases: add VERDE, remove TOSTADO and MOLIDO

### DIFF
--- a/handlers/proceso.py
+++ b/handlers/proceso.py
@@ -100,6 +100,15 @@ async def seleccionar_origen(update: Update, context: ContextTypes.DEFAULT_TYPE)
     if origen in TRANSICIONES_PERMITIDAS:
         destinos_posibles = TRANSICIONES_PERMITIDAS[origen]
         
+        # Si no hay destinos posibles, informar al usuario
+        if not destinos_posibles:
+            await update.message.reply_text(
+                f"⚠️ La fase {origen} no tiene transformaciones posibles.\n"
+                f"Por favor, inicia el proceso nuevamente con otra fase de origen.",
+                reply_markup=ReplyKeyboardRemove()
+            )
+            return ConversationHandler.END
+        
         # Crear teclado con destinos posibles
         keyboard = [[destino] for destino in destinos_posibles]
         reply_markup = ReplyKeyboardMarkup(keyboard, one_time_keyboard=True, resize_keyboard=True)
@@ -113,7 +122,7 @@ async def seleccionar_origen(update: Update, context: ContextTypes.DEFAULT_TYPE)
         return SELECCIONAR_DESTINO
     else:
         await update.message.reply_text(
-            f"⚠️ La fase {origen} no tiene transformaciones posibles."
+            f"⚠️ La fase {origen} no tiene transformaciones posibles.\n"
             f"Por favor, inicia el proceso nuevamente con otra fase de origen.",
             reply_markup=ReplyKeyboardRemove()
         )
@@ -439,9 +448,7 @@ async def ingresar_cantidad(update: Update, context: ContextTypes.DEFAULT_TYPE) 
     mermas_sugeridas = {
         "CEREZO_MOTE": 0.85,      # 85% de pérdida de peso cerezo a mote
         "MOTE_PERGAMINO": 0.20,   # 20% de pérdida de mote a pergamino
-        "PERGAMINO_TOSTADO": 0.18, # 18% de pérdida de pergamino a tostado
-        "TOSTADO_MOLIDO": 0.02,   # 2% de pérdida de tostado a molido
-        "PERGAMINO_MOLIDO": 0.20  # ~20% para transición directa pergamino a molido
+        "PERGAMINO_VERDE": 0.18,  # 18% de pérdida de pergamino a verde
     }
     
     transicion = f"{origen}_{destino}"

--- a/utils/sheets.py
+++ b/utils/sheets.py
@@ -14,14 +14,14 @@ logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s
 logger = logging.getLogger(__name__)
 
 # Definir constantes
-FASES_CAFE = ["CEREZO", "MOTE", "PERGAMINO", "TOSTADO", "MOLIDO"]
+FASES_CAFE = ["CEREZO", "MOTE", "PERGAMINO", "VERDE"]
 
 # Definir transiciones válidas entre fases
 TRANSICIONES_PERMITIDAS = {
     "CEREZO": ["MOTE"],
     "MOTE": ["PERGAMINO"],
-    "PERGAMINO": ["TOSTADO", "MOLIDO"],  # Permitir transición directa a MOLIDO
-    "TOSTADO": ["MOLIDO"]
+    "PERGAMINO": ["VERDE"],
+    "VERDE": []
 }
 
 # Cabeceras para las hojas
@@ -770,7 +770,7 @@ def get_compras_por_fase(fase):
     Obtiene todas las compras en una fase específica con kg disponibles
     
     Args:
-        fase: Fase actual del café (CEREZO, MOTE, PERGAMINO, etc.)
+        fase: Fase actual del café (CEREZO, MOTE, PERGAMINO, VERDE)
         
     Returns:
         Lista de compras en la fase especificada que aún tienen kg disponibles
@@ -830,7 +830,7 @@ def get_almacen_cantidad(fase):
     Obtiene la cantidad disponible de una fase específica del almacén
     
     Args:
-        fase: Fase del café (CEREZO, MOTE, PERGAMINO, etc.)
+        fase: Fase del café (CEREZO, MOTE, PERGAMINO, VERDE)
     
     Returns:
         float: Cantidad disponible en kg
@@ -866,7 +866,7 @@ def update_almacen(fase, cantidad_cambio, operacion="sumar", notas="", compra_id
     Actualiza la cantidad disponible en el almacén para una fase específica
     
     Args:
-        fase: Fase del café (CEREZO, MOTE, PERGAMINO, etc.)
+        fase: Fase del café (CEREZO, MOTE, PERGAMINO, VERDE)
         cantidad_cambio: Cantidad a sumar o restar
         operacion: "sumar" para añadir, "restar" para disminuir, "establecer" para fijar valor
         notas: Notas adicionales sobre la operación


### PR DESCRIPTION
## Description
This PR updates the coffee phases in the bot to align with the new production workflow. The changes include:

1. **Updating coffee phases**:
   - Removed TOSTADO and MOLIDO phases
   - Added VERDE phase
   - Updated the transition flow to match real production: CEREZO → MOTE → PERGAMINO → VERDE

2. **Updating transition rules**:
   - CEREZO can only transition to MOTE
   - MOTE can only transition to PERGAMINO
   - PERGAMINO can only transition to VERDE
   - VERDE has no further transitions (end of process)
   
3. **Updating merma values for new transitions**:
   - Updated transition percentage values in the `mermas_sugeridas` dictionary
   - Added specific value for PERGAMINO → VERDE transition (18%)
   - Removed unnecessary TOSTADO and MOLIDO transitions

4. **Improved error handling**:
   - Added explicit checks for phases with no valid transitions
   - Improved UI messages for users when selecting phases

## Testing
The changes were manually tested to ensure the bot correctly displays the new phases and valid transitions, allowing users to process coffee through the updated workflow.

## Screenshots
None included, but the bot now shows the correct options in the /proceso command UI.

## Notes
This change aligns the bot with the updated process workflow where we focus on the early stages of coffee processing (through VERDE) and do not handle the TOSTADO or MOLIDO stages in our system.