### PR TITLE
Expandir opciones de procesamiento para café PERGAMINO

### DIFF
--- a/handlers/proceso.py
+++ b/handlers/proceso.py
@@ -449,6 +449,10 @@ async def ingresar_cantidad(update: Update, context: ContextTypes.DEFAULT_TYPE) 
         "CEREZO_MOTE": 0.85,      # 85% de pérdida de peso cerezo a mote
         "MOTE_PERGAMINO": 0.20,   # 20% de pérdida de mote a pergamino
         "PERGAMINO_VERDE": 0.18,  # 18% de pérdida de pergamino a verde
+        "PERGAMINO_TOSTADO": 0.20, # 20% de pérdida de pergamino a tostado
+        "PERGAMINO_MOLIDO": 0.25, # 25% de pérdida de pergamino a molido
+        "VERDE_TOSTADO": 0.15,    # 15% de pérdida de verde a tostado
+        "TOSTADO_MOLIDO": 0.05    # 5% de pérdida de tostado a molido
     }
     
     transicion = f"{origen}_{destino}"


### PR DESCRIPTION
## Descripción
Este PR implementa la nueva funcionalidad para el comando `/proceso` que permite procesar el café desde la fase PERGAMINO directamente a VERDE, TOSTADO o MOLIDO.

## Cambios realizados
1. Actualizado el archivo `utils/sheets.py` para:
   - Agregar las fases TOSTADO y MOLIDO a `FASES_CAFE`
   - Modificar las transiciones permitidas para incluir las nuevas opciones para PERGAMINO
   - Agregar las transiciones VERDE → TOSTADO y TOSTADO → MOLIDO

2. Actualizado el archivo `handlers/proceso.py` para:
   - Agregar los porcentajes de merma sugeridos para las nuevas transiciones:
     - PERGAMINO → TOSTADO (20%)
     - PERGAMINO → MOLIDO (25%)
     - VERDE → TOSTADO (15%)
     - TOSTADO → MOLIDO (5%)

## Pruebas
- El usuario ahora puede elegir procesar PERGAMINO directamente a VERDE, TOSTADO o MOLIDO.
- Al seleccionar la opción PERGAMINO → TOSTADO o PERGAMINO → MOLIDO, el sistema calcula la merma correspondiente.
- Las transiciones entre fases se registran correctamente en el almacén.

## Notas adicionales
Se mantiene la compatibilidad con el flujo anterior, permitiendo ahora mayor flexibilidad en el procesamiento del café.
