### PR TITLE
Verificación: El campo de kilos resultantes esperados ya se está guardando

### DIFF
--- a/handlers/proceso.py
+++ b/handlers/proceso.py
@@ -472,6 +472,7 @@ async def ingresar_cantidad(update: Update, context: ContextTypes.DEFAULT_TYPE) 
     cantidad_resultante_esperada = cantidad - merma_sugerida
     
     # Guardar la merma sugerida y cantidad resultante esperada
+    # El campo cantidad_resultante_esperada se guarda posteriormente en la base de datos
     context.user_data['merma_sugerida'] = merma_sugerida
     context.user_data['cantidad_resultante_esperada'] = cantidad_resultante_esperada
     
@@ -616,6 +617,7 @@ async def confirmar(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
         now = get_now_peru()
         
         # Datos para el proceso (actualizados con nuevos campos)
+        # El campo cantidad_resultante_esperada se incluye aquí y se guarda en la base de datos
         proceso_data = {
             "fecha": now.strftime("%Y-%m-%d %H:%M:%S"),
             "origen": origen,
@@ -624,7 +626,7 @@ async def confirmar(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
             "compras_ids": compras_ids_str,  # IDs de compras relacionadas
             "merma": merma,
             "merma_estimada": merma_sugerida,
-            "cantidad_resultante_esperada": cantidad_resultante_esperada,
+            "cantidad_resultante_esperada": cantidad_resultante_esperada,  # Este campo ya se guarda correctamente
             "cantidad_resultante": cantidad_resultante,
             "notas": notas,
             "registrado_por": update.effective_user.username or update.effective_user.first_name


### PR DESCRIPTION
## Análisis del almacenamiento de kilos resultantes esperados

Tras analizar el código, confirmo que **ya se está guardando el campo** `cantidad_resultante_esperada` en la base de datos. Este campo se almacena correctamente en la colección "proceso" y no son necesarias modificaciones adicionales en el código.

### Estructura actual
El código ya incluye la siguiente estructura en la función `confirmar()` de `proceso.py` donde se preparan los datos antes de guardarlos:

```python
# Datos para el proceso (actualizados con nuevos campos)
proceso_data = {
    "fecha": now.strftime("%Y-%m-%d %H:%M:%S"),
    "origen": origen,
    "destino": destino,
    "cantidad": cantidad,
    "compras_ids": compras_ids_str,  # IDs de compras relacionadas
    "merma": merma,
    "merma_estimada": merma_sugerida,
    "cantidad_resultante_esperada": cantidad_resultante_esperada,  # Este es el campo que guarda los kilos esperados
    "cantidad_resultante": cantidad_resultante,
    "notas": notas,
    "registrado_por": update.effective_user.username or update.effective_user.first_name
}
```

### Confirmación en la estructura de la hoja
También se ha verificado que en el archivo `utils/sheets.py` la hoja "proceso" está correctamente configurada para incluir este campo:

```python
# Cabeceras para las hojas
HEADERS = {
    ...
    "proceso": ["fecha", "origen", "destino", "cantidad", "compras_ids", "merma", "merma_estimada", "cantidad_resultante_esperada", "cantidad_resultante", "notas", "registrado_por"],
    ...
}
```

### Conclusión
No es necesario realizar cambios en el código, ya que el campo solicitado ya se está guardando correctamente en la base de datos. Solo he añadido comentarios adicionales para hacer más evidente que este campo se almacena.