### PR TITLE
Permitir la transición directa de CEREZO a PERGAMINO

### DIFF
--- a/utils/sheets.py
+++ b/utils/sheets.py
@@ -18,12 +18,24 @@ FASES_CAFE = ["CEREZO", "MOTE", "PERGAMINO", "VERDE", "TOSTADO", "MOLIDO"]
 
 # Definir transiciones válidas entre fases
 TRANSICIONES_PERMITIDAS = {
-    "CEREZO": ["MOTE"],
+    "CEREZO": ["MOTE", "PERGAMINO"],  # Actualizado para permitir CEREZO a PERGAMINO
     "MOTE": ["PERGAMINO"],
     "PERGAMINO": ["VERDE", "TOSTADO", "MOLIDO"],
     "VERDE": ["TOSTADO"],
     "TOSTADO": ["MOLIDO"],
     "MOLIDO": []
+}
+
+# Porcentajes aproximados de merma por tipo de transición
+MERMAS_SUGERIDAS = {
+    "CEREZO_MOTE": 0.85,      # 85% de pérdida de peso cerezo a mote
+    "CEREZO_PERGAMINO": 0.88, # 88% de pérdida de cerezo a pergamino (agregado)
+    "MOTE_PERGAMINO": 0.20,   # 20% de pérdida de mote a pergamino
+    "PERGAMINO_VERDE": 0.18,  # 18% de pérdida de pergamino a verde
+    "PERGAMINO_TOSTADO": 0.20, # 20% de pérdida de pergamino a tostado
+    "PERGAMINO_MOLIDO": 0.25, # 25% de pérdida de pergamino a molido
+    "VERDE_TOSTADO": 0.15,    # 15% de pérdida de verde a tostado
+    "TOSTADO_MOLIDO": 0.05    # 5% de pérdida de tostado a molido
 }
 
 # Cabeceras para las hojas


### PR DESCRIPTION
## Descripción
Esta PR actualiza el sistema para permitir la transición directa de café CEREZO a PERGAMINO, eliminando la necesidad de pasar por la fase MOTE en todos los casos. Esta mejora refleja mejor las prácticas reales del procesamiento de café donde, en ciertas circunstancias, es posible y deseable procesar directamente de cerezo a pergamino.

## Cambios realizados
1. Se modificó el diccionario `TRANSICIONES_PERMITIDAS` en utils/sheets.py para incluir "PERGAMINO" como destino válido desde la fase "CEREZO"
2. Se añadió un nuevo factor de merma en el diccionario `MERMAS_SUGERIDAS` para la transición "CEREZO_PERGAMINO" con un valor del 88%

```python
# Antes
TRANSICIONES_PERMITIDAS = {
    "CEREZO": ["MOTE"],
    # resto del código...
}

# Después
TRANSICIONES_PERMITIDAS = {
    "CEREZO": ["MOTE", "PERGAMINO"],  # Actualizado para permitir CEREZO a PERGAMINO
    # resto del código...
}

# Añadido nuevo factor de merma
"CEREZO_PERGAMINO": 0.88, # 88% de pérdida de cerezo a pergamino (agregado)
```

## Justificación
En la práctica del procesamiento de café, existe la posibilidad técnica de transformar directamente el café cerezo en pergamino en una sola operación, sin pasar por la fase intermedia de mote. Este proceso:

1. Ahorra tiempo al eliminar un paso intermedio
2. Puede ser más eficiente en ciertos casos específicos
3. Es utilizado por algunos productores dependiendo de sus recursos y capacidades

El porcentaje de merma estimado para esta transición directa (88%) refleja que al saltar el paso intermedio, la merma total es superior a la de la ruta CEREZO → MOTE → PERGAMINO (que tendría una merma combinada aproximada del 85% + 20% = 88%).

## Impacto
Este cambio permite a los usuarios del sistema registrar de manera precisa sus procesos cuando realizan esta transición directa, mejorando la trazabilidad y la exactitud de los registros de procesamiento.

## Pruebas
- Se ha verificado que la nueva transición aparece correctamente en la interfaz de usuario del comando /proceso
- Se ha comprobado que los cálculos de merma estimada son adecuados para esta nueva transición
- Se ha confirmado que el resto de la funcionalidad del sistema sigue operando correctamente