### PR TITLE
Permitir transición de CEREZO a PERGAMINO en proceso de café

### DIFF
--- a/handlers/proceso.py
+++ b/handlers/proceso.py
@@ -23,6 +23,7 @@ SELECCIONAR_ORIGEN, SELECCIONAR_DESTINO, SELECCIONAR_REGISTROS_ALMACEN, INGRESAR
 # Porcentajes aproximados de merma por tipo de transición
 MERMAS_SUGERIDAS = {
     "CEREZO_MOTE": 0.85,      # 85% de pérdida de peso cerezo a mote
+    "CEREZO_PERGAMINO": 0.88, # 88% de pérdida de peso cerezo a pergamino
     "MOTE_PERGAMINO": 0.20,   # 20% de pérdida de mote a pergamino
     "PERGAMINO_VERDE": 0.18,  # 18% de pérdida de pergamino a verde
     "PERGAMINO_TOSTADO": 0.20, # 20% de pérdida de pergamino a tostado

--- a/utils/sheets.py
+++ b/utils/sheets.py
@@ -18,7 +18,7 @@ FASES_CAFE = ["CEREZO", "MOTE", "PERGAMINO", "VERDE", "TOSTADO", "MOLIDO"]
 
 # Definir transiciones válidas entre fases
 TRANSICIONES_PERMITIDAS = {
-    "CEREZO": ["MOTE"],
+    "CEREZO": ["MOTE", "PERGAMINO"],
     "MOTE": ["PERGAMINO"],
     "PERGAMINO": ["VERDE", "TOSTADO", "MOLIDO"],
     "VERDE": ["TOSTADO"],


### PR DESCRIPTION
## Descripción
Esta modificación permite la transición directa de café CEREZO a PERGAMINO cuando se ejecuta un proceso, sin necesidad de pasar por el estado intermedio MOTE.

## Cambios realizados
1. Actualizado el diccionario `TRANSICIONES_PERMITIDAS` en `utils/sheets.py` para incluir PERGAMINO como destino posible desde CEREZO
2. Añadido el porcentaje de merma sugerida para la transición CEREZO_PERGAMINO (88%) en `handlers/proceso.py`

## Justificación
Esta mejora optimiza el flujo de trabajo de procesamiento de café para aquellos casos donde se quiere transformar directamente de cereza a pergamino, permitiendo saltar el estado intermedio de café en mote cuando sea necesario.

## Pruebas realizadas
- Se verificó que el flujo de trabajo del proceso ahora ofrece PERGAMINO como una opción cuando el origen es CEREZO
- El cálculo de merma genera un valor apropiado (88%) para esta transición

## Impacto
- Los usuarios ahora pueden transformar café CEREZO directamente a PERGAMINO
- Se mantienen todas las funcionalidades previas, solo se añade una nueva opción de transformación