### PR TITLE
Mejorar formato de presentación de registros de almacén

### DIFF
--- a/handlers/proceso.py
+++ b/handlers/proceso.py
@@ -232,12 +232,12 @@ async def seleccionar_destino(update: Update, context: ContextTypes.DEFAULT_TYPE
         # Extraer solo la fecha sin la hora
         fecha_solo = fecha.split(" ")[0] if " " in fecha else fecha
         
-        # Añadir fila de información con el formato ID, PROVEEDOR, FECHA
-        mensaje += f"{i+1}. {registro_id}, {proveedor}, {fecha_solo}\n"
+        # Añadir fila de información con el NUEVO formato: proveedor - id - kg - fecha
+        mensaje += f"{i+1}. {proveedor} - {registro_id} - {kg_disponibles} kg - {fecha_solo}\n"
         
-        # Crear botón para este registro
+        # Crear botón para este registro con el NUEVO formato
         keyboard.append([
-            InlineKeyboardButton(f"{registro_id} - {kg_disponibles} kg", callback_data=f"registro_{i}")
+            InlineKeyboardButton(f"{proveedor} - {registro_id} - {kg_disponibles} kg - {fecha_solo}", callback_data=f"registro_{i}")
         ])
     
     # Añadir botón para selección múltiple personalizada
@@ -268,12 +268,23 @@ async def seleccionar_registros_callback(update: Update, context: ContextTypes.D
         # Calcular total de kg disponibles
         total_kg = sum(safe_float(registro.get('cantidad_actual', 0)) for registro in almacen_disponible)
         
-        # Formatear mensaje con los registros seleccionados
+        # Formatear mensaje con los registros seleccionados en el NUEVO formato
         seleccionados_info = []
         for registro in almacen_disponible:
+            # Buscar información del proveedor
+            proveedor = "Desconocido"
+            compra_id = registro.get('compra_id', '')
+            if compra_id:
+                compras = get_filtered_data('compras', {'id': compra_id})
+                if compras:
+                    proveedor = compras[0].get('proveedor', 'Desconocido')
+                    
             kg = safe_float(registro.get('cantidad_actual', 0))
             registro_id = registro.get('id', 'Sin ID')
-            seleccionados_info.append(f"{registro_id} ({kg} kg)")
+            fecha = registro.get('fecha', 'Sin fecha')
+            fecha_solo = fecha.split(" ")[0] if " " in fecha else fecha
+            
+            seleccionados_info.append(f"{proveedor} - {registro_id} - {kg} kg - {fecha_solo}")
         
         seleccionados_texto = "\n- ".join([""] + seleccionados_info)
         
@@ -300,11 +311,23 @@ async def seleccionar_registros_callback(update: Update, context: ContextTypes.D
             kg_disponibles = safe_float(registro.get('cantidad_actual', 0))
             registro_id = registro.get('id', 'Sin ID')
             
-            # Estado inicial: no seleccionado
+            # Buscar información del proveedor
+            proveedor = "Desconocido"
+            compra_id = registro.get('compra_id', '')
+            if compra_id:
+                compras = get_filtered_data('compras', {'id': compra_id})
+                if compras:
+                    proveedor = compras[0].get('proveedor', 'Desconocido')
+            
+            # Extraer fecha sin hora
+            fecha = registro.get('fecha', 'Sin fecha')
+            fecha_solo = fecha.split(" ")[0] if " " in fecha else fecha
+            
+            # Estado inicial: no seleccionado con el NUEVO formato
             checkbox = "☐"  # Checkbox vacío
             keyboard.append([
                 InlineKeyboardButton(
-                    f"{checkbox} {registro_id} - {kg_disponibles} kg", 
+                    f"{checkbox} {proveedor} - {registro_id} - {kg_disponibles} kg - {fecha_solo}", 
                     callback_data=f"toggle_{i}"
                 )
             ])
@@ -344,11 +367,23 @@ async def seleccionar_registros_callback(update: Update, context: ContextTypes.D
             kg_disponibles = safe_float(registro.get('cantidad_actual', 0))
             registro_id = registro.get('id', 'Sin ID')
             
+            # Buscar información del proveedor
+            proveedor = "Desconocido"
+            compra_id = registro.get('compra_id', '')
+            if compra_id:
+                compras = get_filtered_data('compras', {'id': compra_id})
+                if compras:
+                    proveedor = compras[0].get('proveedor', 'Desconocido')
+            
+            # Extraer fecha sin hora
+            fecha = registro.get('fecha', 'Sin fecha')
+            fecha_solo = fecha.split(" ")[0] if " " in fecha else fecha
+            
             # Checkbox state based on selection
             checkbox = "☑" if str(i) in multi_seleccion else "☐"
             keyboard.append([
                 InlineKeyboardButton(
-                    f"{checkbox} {registro_id} - {kg_disponibles} kg", 
+                    f"{checkbox} {proveedor} - {registro_id} - {kg_disponibles} kg - {fecha_solo}", 
                     callback_data=f"toggle_{i}"
                 )
             ])
@@ -391,12 +426,23 @@ async def seleccionar_registros_callback(update: Update, context: ContextTypes.D
         # Calcular total de kg disponibles
         total_kg = sum(safe_float(registro.get('cantidad_actual', 0)) for registro in registros_seleccionados)
         
-        # Formatear mensaje con los registros seleccionados
+        # Formatear mensaje con los registros seleccionados (NUEVO formato)
         seleccionados_info = []
         for registro in registros_seleccionados:
+            # Buscar información del proveedor
+            proveedor = "Desconocido"
+            compra_id = registro.get('compra_id', '')
+            if compra_id:
+                compras = get_filtered_data('compras', {'id': compra_id})
+                if compras:
+                    proveedor = compras[0].get('proveedor', 'Desconocido')
+                    
             kg = safe_float(registro.get('cantidad_actual', 0))
             registro_id = registro.get('id', 'Sin ID')
-            seleccionados_info.append(f"{registro_id} ({kg} kg)")
+            fecha = registro.get('fecha', 'Sin fecha')
+            fecha_solo = fecha.split(" ")[0] if " " in fecha else fecha
+            
+            seleccionados_info.append(f"{proveedor} - {registro_id} - {kg} kg - {fecha_solo}")
         
         seleccionados_texto = "\n- ".join([""] + seleccionados_info)
         
@@ -421,13 +467,25 @@ async def seleccionar_registros_callback(update: Update, context: ContextTypes.D
         context.user_data['registros_seleccionados'] = [almacen_disponible[indice]]
         total_kg = safe_float(almacen_disponible[indice].get('cantidad_actual', 0))
         
-        # Formatear mensaje
+        # Formatear mensaje con el NUEVO formato
         registro = almacen_disponible[indice]
         kg = safe_float(registro.get('cantidad_actual', 0))
         registro_id = registro.get('id', 'Sin ID')
         
+        # Buscar información del proveedor
+        proveedor = "Desconocido"
+        compra_id = registro.get('compra_id', '')
+        if compra_id:
+            compras = get_filtered_data('compras', {'id': compra_id})
+            if compras:
+                proveedor = compras[0].get('proveedor', 'Desconocido')
+        
+        # Extraer fecha sin hora
+        fecha = registro.get('fecha', 'Sin fecha')
+        fecha_solo = fecha.split(" ")[0] if " " in fecha else fecha
+        
         await query.edit_message_text(
-            f"🛒 Has seleccionado el registro:\n- {registro_id} ({kg} kg)\n\n"
+            f"🛒 Has seleccionado el registro:\n- {proveedor} - {registro_id} - {kg} kg - {fecha_solo}\n\n"
             f"Total disponible: {total_kg} kg\n\n"
             f"¿Cuántos kg de café {origen} deseas transformar a {destino}?"
         )
@@ -554,12 +612,23 @@ async def agregar_notas(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
     cantidad_resultante_esperada = context.user_data['cantidad_resultante_esperada']
     registros_seleccionados = context.user_data['registros_seleccionados']
     
-    # Formatear información de registros (simplificado, sin mostrar proveedor)
+    # Formatear información de registros con el NUEVO formato
     registros_info = []
     for registro in registros_seleccionados:
+        # Obtener información del proveedor
+        proveedor = "Desconocido"
+        compra_id = registro.get('compra_id', '')
+        if compra_id:
+            compras = get_filtered_data('compras', {'id': compra_id})
+            if compras:
+                proveedor = compras[0].get('proveedor', 'Desconocido')
+        
         kg = safe_float(registro.get('cantidad_actual', 0))
         registro_id = registro.get('id', 'Sin ID')
-        registros_info.append(f"{registro_id} ({kg} kg)")
+        fecha = registro.get('fecha', 'Sin fecha')
+        fecha_solo = fecha.split(" ")[0] if " " in fecha else fecha
+        
+        registros_info.append(f"{proveedor} - {registro_id} - {kg} kg - {fecha_solo}")
     
     registros_texto = "\n- ".join([""] + registros_info)
     


### PR DESCRIPTION
## Descripción
Esta modificación mejora el formato de presentación de los registros de almacén en el comando `/proceso` para hacerlo más fácil de entender e identificar para los usuarios.

## Cambios realizados
He actualizado el formato de presentación de registros en el módulo `handlers/proceso.py` para que siga el formato:
```
proveedor - id - kg - fecha (solo fecha sin hora)
```

Los cambios afectan a:
- Listado inicial de registros disponibles
- Botones de selección individual de registros
- Interfaz de selección múltiple de registros
- Resumen de registros seleccionados
- Confirmación final del proceso

## Justificación
La imagen compartida muestra que el formato actual dificulta que los usuarios identifiquen adecuadamente los registros de almacén. Con este nuevo formato, los registros son más legibles y contienen la información esencial ordenada de manera lógica:
1. Nombre del proveedor (dato principal para identificación)
2. ID del registro (para referencia técnica)
3. Cantidad disponible en kg (dato crítico para el procesamiento)
4. Fecha del registro (solo la fecha, sin la hora, para simplificar)

## Impacto
Esta mejora es puramente visual y no afecta la funcionalidad del bot. Simplemente reorganiza la información para facilitar la experiencia del usuario al seleccionar registros de almacén durante el procesamiento de café.

## Pruebas realizadas
Se ha verificado que:
- La información se muestra correctamente en todas las etapas del proceso
- Los botones muestran la información completa
- La selección múltiple mantiene el formato consistente
- El resumen del proceso muestra correctamente los registros según el nuevo formato