### PR TITLE
Corregir error de sintaxis en utils/sheets/__init__.py

### DIFF
--- a/utils/sheets/__init__.py
+++ b/utils/sheets/__init__.py
@@ -1,1 +1,55 @@
-"""\nInicialización del paquete utils/sheets refactorizado.\nEste archivo expone todas las funciones necesarias para mantener compatibilidad con el código existente.\n"""\n\n# Constantes\nfrom utils.sheets.constants import (\n    FASES_CAFE,\n    TRANSICIONES_PERMITIDAS,\n    MERMAS_SUGERIDAS,\n    HEADERS\n)\n\n# Servicios\nfrom utils.sheets.service import (\n    get_sheet_service,\n    get_or_create_sheet,\n    get_sheets_initialized,\n    set_sheets_initialized\n)\n\n# Funciones principales (core)\nfrom utils.sheets.core import (\n    initialize_sheets,\n    append_data,\n    update_cell,\n    get_all_data,\n    get_filtered_data\n)\n\n# Funciones de almacén\nfrom utils.sheets.almacen import (\n    get_compras_por_fase,\n    get_almacen_cantidad,\n    update_almacen_tostado,\n    update_almacen,\n    leer_almacen_para_proceso,\n    sincronizar_almacen_con_compras\n)\n\n# Funciones de proceso\nfrom utils.sheets.process import (\n    es_transicion_valida,\n    calcular_merma_sugerida,\n    actualizar_almacen_desde_proceso\n)\n\n# Utilidades\nfrom utils.sheets.utils import (\n    generate_unique_id,\n    generate_almacen_id,\n    format_date_for_sheets,\n    get_current_datetime_str,\n    safe_float\n)
+"""
+Inicialización del paquete utils/sheets refactorizado.
+Este archivo expone todas las funciones necesarias para mantener compatibilidad con el código existente.
+"""
+
+# Constantes
+from utils.sheets.constants import (
+    FASES_CAFE,
+    TRANSICIONES_PERMITIDAS,
+    MERMAS_SUGERIDAS,
+    HEADERS
+)
+
+# Servicios
+from utils.sheets.service import (
+    get_sheet_service,
+    get_or_create_sheet,
+    get_sheets_initialized,
+    set_sheets_initialized
+)
+
+# Funciones principales (core)
+from utils.sheets.core import (
+    initialize_sheets,
+    append_data,
+    update_cell,
+    get_all_data,
+    get_filtered_data
+)
+
+# Funciones de almacén
+from utils.sheets.almacen import (
+    get_compras_por_fase,
+    get_almacen_cantidad,
+    update_almacen_tostado,
+    update_almacen,
+    leer_almacen_para_proceso,
+    sincronizar_almacen_con_compras
+)
+
+# Funciones de proceso
+from utils.sheets.process import (
+    es_transicion_valida,
+    calcular_merma_sugerida,
+    actualizar_almacen_desde_proceso
+)
+
+# Utilidades
+from utils.sheets.utils import (
+    generate_unique_id,
+    generate_almacen_id,
+    format_date_for_sheets,
+    get_current_datetime_str,
+    safe_float
+)


### PR DESCRIPTION
Este PR corrige el error de sintaxis en el archivo `utils/sheets/__init__.py` que estaba causando que la aplicación fallara al iniciar.

## Error original
```
SyntaxError: unexpected character after line continuation character
```

## Solución
El error se debía a un problema en el formateado del archivo de inicialización del módulo sheets, específicamente en las importaciones. He restaurado el archivo a su formato correcto, asegurando que las importaciones estén correctamente escritas.

## Pruebas
Este cambio debería permitir que la aplicación inicie correctamente sin el error de sintaxis que se estaba reportando.

Fixes: #N/A
