### PR TITLE
Corregir error de sintaxis en utils/sheets/constants.py

### DIFF
--- a/utils/sheets/constants.py
+++ b/utils/sheets/constants.py
@@ -1,1 +1,39 @@
-"""\nMódulo que contiene las constantes utilizadas por el sistema de hojas de cálculo.\n"""\n\n# Definir constantes\nFASES_CAFE = ["CEREZO", "MOTE", "PERGAMINO", "VERDE", "TOSTADO", "MOLIDO"]\n\n# Definir transiciones válidas entre fases\nTRANSICIONES_PERMITIDAS = {\n    "CEREZO": ["MOTE", "PERGAMINO"],  # Actualizado para permitir CEREZO a PERGAMINO\n    "MOTE": ["PERGAMINO"],\n    "PERGAMINO": ["VERDE", "TOSTADO", "MOLIDO"],\n    "VERDE": ["TOSTADO"],\n    "TOSTADO": ["MOLIDO"],\n    "MOLIDO": []\n}\n\n# Porcentajes aproximados de merma por tipo de transición\nMERMAS_SUGERIDAS = {\n    "CEREZO_MOTE": 0.85,      # 85% de pérdida de peso cerezo a mote\n    "CEREZO_PERGAMINO": 0.88, # 88% de pérdida de cerezo a pergamino (agregado)\n    "MOTE_PERGAMINO": 0.20,   # 20% de pérdida de mote a pergamino\n    "PERGAMINO_VERDE": 0.18,  # 18% de pérdida de pergamino a verde\n    "PERGAMINO_TOSTADO": 0.20, # 20% de pérdida de pergamino a tostado\n    "PERGAMINO_MOLIDO": 0.25, # 25% de pérdida de pergamino a molido\n    "VERDE_TOSTADO": 0.15,    # 15% de pérdida de verde a tostado\n    "TOSTADO_MOLIDO": 0.05    # 5% de pérdida de tostado a molido\n}\n\n# Cabeceras para las hojas\nHEADERS = {\n    "compras": ["id", "fecha", "tipo_cafe", "proveedor", "cantidad", "precio", "preciototal", "registrado_por", "notas"],\n    "proceso": ["fecha", "origen", "destino", "cantidad", "compras_ids", "merma", "merma_estimada", "cantidad_resultante_esperada", "cantidad_resultante", "notas", "registrado_por"],\n    "gastos": ["fecha", "categoria", "monto", "descripcion", "registrado_por"],\n    "ventas": ["fecha", "cliente", "tipo_cafe", "peso", "precio_kg", "total", "almacen_id", "notas", "registrado_por"],\n    "pedidos": ["fecha", "cliente", "tipo_cafe", "cantidad", "precio_kg", "total", "estado", "fecha_entrega", "notas", "registrado_por"],\n    "adelantos": ["fecha", "hora", "cliente", "monto", "notas", "registrado_por"],\n    "almacen": ["id", "compra_id", "tipo_cafe_origen", "fecha", "cantidad", "fase_actual", "cantidad_actual", "notas", "fecha_actualizacion"]\n}
+"""
+Módulo que contiene las constantes utilizadas por el sistema de hojas de cálculo.
+"""
+
+# Definir constantes
+FASES_CAFE = ["CEREZO", "MOTE", "PERGAMINO", "VERDE", "TOSTADO", "MOLIDO"]
+
+# Definir transiciones válidas entre fases
+TRANSICIONES_PERMITIDAS = {
+    "CEREZO": ["MOTE", "PERGAMINO"],  # Actualizado para permitir CEREZO a PERGAMINO
+    "MOTE": ["PERGAMINO"],
+    "PERGAMINO": ["VERDE", "TOSTADO", "MOLIDO"],
+    "VERDE": ["TOSTADO"],
+    "TOSTADO": ["MOLIDO"],
+    "MOLIDO": []
+}
+
+# Porcentajes aproximados de merma por tipo de transición
+MERMAS_SUGERIDAS = {
+    "CEREZO_MOTE": 0.85,      # 85% de pérdida de peso cerezo a mote
+    "CEREZO_PERGAMINO": 0.88, # 88% de pérdida de cerezo a pergamino (agregado)
+    "MOTE_PERGAMINO": 0.20,   # 20% de pérdida de mote a pergamino
+    "PERGAMINO_VERDE": 0.18,  # 18% de pérdida de pergamino a verde
+    "PERGAMINO_TOSTADO": 0.20, # 20% de pérdida de pergamino a tostado
+    "PERGAMINO_MOLIDO": 0.25, # 25% de pérdida de pergamino a molido
+    "VERDE_TOSTADO": 0.15,    # 15% de pérdida de verde a tostado
+    "TOSTADO_MOLIDO": 0.05    # 5% de pérdida de tostado a molido
+}
+
+# Cabeceras para las hojas
+HEADERS = {
+    "compras": ["id", "fecha", "tipo_cafe", "proveedor", "cantidad", "precio", "preciototal", "registrado_por", "notas"],
+    "proceso": ["fecha", "origen", "destino", "cantidad", "compras_ids", "merma", "merma_estimada", "cantidad_resultante_esperada", "cantidad_resultante", "notas", "registrado_por"],
+    "gastos": ["fecha", "categoria", "monto", "descripcion", "registrado_por"],
+    "ventas": ["fecha", "cliente", "tipo_cafe", "peso", "precio_kg", "total", "almacen_id", "notas", "registrado_por"],
+    "pedidos": ["fecha", "cliente", "tipo_cafe", "cantidad", "precio_kg", "total", "estado", "fecha_entrega", "notas", "registrado_por"],
+    "adelantos": ["fecha", "hora", "cliente", "monto", "notas", "registrado_por"],
+    "almacen": ["id", "compra_id", "tipo_cafe_origen", "fecha", "cantidad", "fase_actual", "cantidad_actual", "notas", "fecha_actualizacion"]
+}


### PR DESCRIPTION
Este PR corrige el error de sintaxis en el archivo `utils/sheets/constants.py` que está causando que la aplicación falle al iniciarse en Heroku.

## Error original
```
File "/app/utils/sheets/constants.py", line 1
  , "fecha", "cantidad", "fase_actual", "cantidad_actual", "notas", "fecha_actualizacion"]\n}
                                                                              ^
SyntaxError: unexpected character after line continuation character
```

## Problema detectado
El archivo `constants.py` en Heroku parece estar truncado o corrompido. El error muestra que comienza con una coma seguida de elementos que deberían estar en medio de una lista, lo que indica que falta el inicio del archivo.

## Solución
He restaurado completamente el archivo `constants.py` con su contenido correcto, asegurando que tenga la estructura adecuada y sin caracteres de escape inesperados.

## Pruebas
Después de aplicar este cambio, la aplicación debería iniciar correctamente sin errores de sintaxis en los archivos de importación.

Fixes: #N/A