### PR TITLE
Corregir error de sintaxis en utils/sheets/process.py

### DIFF
--- a/utils/sheets/process.py
+++ b/utils/sheets/process.py
@@ -1,1 +1,97 @@
-"""\nMódulo para gestionar los procesos de transformación del café en el sistema de hojas de cálculo.\n"""\nimport logging\n\nfrom utils.sheets.constants import TRANSICIONES_PERMITIDAS, MERMAS_SUGERIDAS\nfrom utils.sheets.almacen import update_almacen\n\n# Configurar logging\nlogger = logging.getLogger(__name__)\n\ndef es_transicion_valida(origen, destino):\n    """\n    Verifica si la transición de fase es válida.\n    \n    Args:\n        origen: Fase de origen\n        destino: Fase de destino\n        \n    Returns:\n        bool: True si la transición es válida, False en caso contrario\n    """\n    if origen not in TRANSICIONES_PERMITIDAS:\n        return False\n    \n    return destino in TRANSICIONES_PERMITIDAS[origen]\n\ndef calcular_merma_sugerida(origen, destino, cantidad):\n    """\n    Calcula la merma sugerida para una transición específica.\n    \n    Args:\n        origen: Fase de origen\n        destino: Fase de destino\n        cantidad: Cantidad a procesar en kg\n        \n    Returns:\n        float: Merma sugerida en kg\n    """\n    try:\n        # Construir clave para buscar en el diccionario de mermas\n        clave_merma = f"{origen}_{destino}"\n        \n        # Verificar si existe un porcentaje de merma para esta transición\n        if clave_merma in MERMAS_SUGERIDAS:\n            factor_merma = MERMAS_SUGERIDAS[clave_merma]\n            merma_calculada = float(cantidad) * factor_merma\n            return round(merma_calculada, 2)\n        \n        return 0.0\n    except Exception as e:\n        logger.error(f"Error al calcular merma sugerida: {e}")\n        return 0.0\n\ndef actualizar_almacen_desde_proceso(origen, destino, cantidad, merma):\n    """\n    Actualiza el almacén basado en un proceso de transformación.\n    \n    Args:\n        origen: Fase de origen del café\n        destino: Fase de destino del café\n        cantidad: Cantidad procesada en kg\n        merma: Cantidad de merma en kg\n    \n    Returns:\n        bool: True si se actualizó correctamente, False en caso contrario\n    """\n    try:\n        logger.info(f"Actualizando almacén desde proceso - Origen: {origen}, Destino: {destino}, Cantidad: {cantidad} kg, Merma: {merma} kg")\n        \n        # 1. Restar la cantidad procesada de la fase de origen\n        resultado_origen = update_almacen(\n            fase=origen,\n            cantidad_cambio=cantidad,\n            operacion="restar",\n            notas=f"Proceso a {destino}"\n        )\n        \n        # Manejar el caso donde resultado_origen es una tuple (usado en ventas)\n        if isinstance(resultado_origen, tuple):\n            resultado_origen = resultado_origen[0]\n        \n        # 2. Calcular cantidad resultante (restando merma)\n        cantidad_resultante = max(0, float(cantidad) - float(merma))\n        \n        # 3. Sumar la cantidad resultante a la fase de destino\n        resultado_destino = update_almacen(\n            fase=destino,\n            cantidad_cambio=cantidad_resultante,\n            operacion="sumar",\n            notas=f"Procesado desde {origen}"\n        )\n        \n        return resultado_origen and resultado_destino\n    except Exception as e:\n        logger.error(f"Error al actualizar almacén desde proceso: {e}")\n        return False
+"""
+Módulo para gestionar los procesos de transformación del café en el sistema de hojas de cálculo.
+"""
+import logging
+
+from utils.sheets.constants import TRANSICIONES_PERMITIDAS, MERMAS_SUGERIDAS
+from utils.sheets.almacen import update_almacen
+
+# Configurar logging
+logger = logging.getLogger(__name__)
+
+def es_transicion_valida(origen, destino):
+    """
+    Verifica si la transición de fase es válida.
+    
+    Args:
+        origen: Fase de origen
+        destino: Fase de destino
+        
+    Returns:
+        bool: True si la transición es válida, False en caso contrario
+    """
+    if origen not in TRANSICIONES_PERMITIDAS:
+        return False
+    
+    return destino in TRANSICIONES_PERMITIDAS[origen]
+
+def calcular_merma_sugerida(origen, destino, cantidad):
+    """
+    Calcula la merma sugerida para una transición específica.
+    
+    Args:
+        origen: Fase de origen
+        destino: Fase de destino
+        cantidad: Cantidad a procesar en kg
+        
+    Returns:
+        float: Merma sugerida en kg
+    """
+    try:
+        # Construir clave para buscar en el diccionario de mermas
+        clave_merma = f"{origen}_{destino}"
+        
+        # Verificar si existe un porcentaje de merma para esta transición
+        if clave_merma in MERMAS_SUGERIDAS:
+            factor_merma = MERMAS_SUGERIDAS[clave_merma]
+            merma_calculada = float(cantidad) * factor_merma
+            return round(merma_calculada, 2)
+        
+        return 0.0
+    except Exception as e:
+        logger.error(f"Error al calcular merma sugerida: {e}")
+        return 0.0
+
+def actualizar_almacen_desde_proceso(origen, destino, cantidad, merma):
+    """
+    Actualiza el almacén basado en un proceso de transformación.
+    
+    Args:
+        origen: Fase de origen del café
+        destino: Fase de destino del café
+        cantidad: Cantidad procesada en kg
+        merma: Cantidad de merma en kg
+    
+    Returns:
+        bool: True si se actualizó correctamente, False en caso contrario
+    """
+    try:
+        logger.info(f"Actualizando almacén desde proceso - Origen: {origen}, Destino: {destino}, Cantidad: {cantidad} kg, Merma: {merma} kg")
+        
+        # 1. Restar la cantidad procesada de la fase de origen
+        resultado_origen = update_almacen(
+            fase=origen,
+            cantidad_cambio=cantidad,
+            operacion="restar",
+            notas=f"Proceso a {destino}"
+        )
+        
+        # Manejar el caso donde resultado_origen es una tuple (usado en ventas)
+        if isinstance(resultado_origen, tuple):
+            resultado_origen = resultado_origen[0]
+        
+        # 2. Calcular cantidad resultante (restando merma)
+        cantidad_resultante = max(0, float(cantidad) - float(merma))
+        
+        # 3. Sumar la cantidad resultante a la fase de destino
+        resultado_destino = update_almacen(
+            fase=destino,
+            cantidad_cambio=cantidad_resultante,
+            operacion="sumar",
+            notas=f"Procesado desde {origen}"
+        )
+        
+        return resultado_origen and resultado_destino
+    except Exception as e:
+        logger.error(f"Error al actualizar almacén desde proceso: {e}")
+        return False


### PR DESCRIPTION
Este PR corrige el error de sintaxis en el archivo `utils/sheets/process.py` que está causando que la aplicación falle al iniciarse en Heroku.

## Error original
```
File "/app/utils/sheets/process.py", line 1
  ntidad_cambio=cantidad_resultante,\n            operacion="sumar",\n            notas=f"Procesado desde {origen}"\n        )\n        \n        return resultado_origen and resultado_destino\n    except Exception as e:\n        logger.error(f"Error al actualizar almacén desde proceso: {e}")\n        return False
                                                                                                   ^
SyntaxError: unexpected character after line continuation character
```

## Problema detectado
El archivo `process.py` en Heroku también está truncado o corrupto, empezando con parte del final de la función `actualizar_almacen_desde_proceso()` en lugar del inicio correcto del archivo.

## Solución
He restaurado completamente el archivo `process.py` con su contenido correcto, asegurando que tenga la estructura adecuada y sin caracteres de escape inesperados.

## Pruebas
Después de aplicar este cambio, la aplicación debería continuar con el proceso de inicialización sin errores de sintaxis en los archivos de importación.

Fixes: #N/A