### PR TITLE
Corregir funcionalidad del comando /documento

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -185,6 +185,17 @@ def main():
             logger.error(f"Error al registrar handler de documentos: {e}")
             logger.error(traceback.format_exc())
             handlers_fallidos += 1
+            
+            # Fix para el handler de documentos - Registro manual del comando
+            try:
+                logger.info("Intentando registrar CommandHandler para /documento directamente...")
+                from handlers.documents import documento_command
+                application.add_handler(CommandHandler("documento", documento_command))
+                logger.info("CommandHandler para /documento registrado manualmente con éxito")
+                handlers_registrados += 1
+            except Exception as e_fix:
+                logger.error(f"Error al intentar registrar CommandHandler directo para /documento: {e_fix}")
+                logger.error(traceback.format_exc())
     else:
         logger.error("No se pudo registrar el handler de documentos: Módulo no disponible")
         handlers_fallidos += 1


### PR DESCRIPTION
## Descripción del problema

El comando `/documento` no estaba funcionando correctamente. En la imagen de la conversación se puede ver que el usuario intenta usar el comando varias veces pero no obtiene respuesta.

## Causa del problema

El problema se debe a que el registro del handler del comando `/documento` dentro del ConversationHandler falla cuando hay un error en `register_documents_handlers`. Sin embargo, el código no proporciona un método alternativo para registrar el comando directamente, lo que hace que el comando `/documento` no responda.

## Solución implementada

He añadido un bloque adicional dentro del manejo de excepciones para el registro del handler de documentos que intentará registrar el CommandHandler para `/documento` directamente en caso de que el registro del ConversationHandler falle. 

Esto proporciona un mecanismo de respaldo que permite que el comando `/documento` funcione incluso si hay algún problema con el registro completo del ConversationHandler.

```python
# Fix para el handler de documentos - Registro manual del comando
try:
    logger.info("Intentando registrar CommandHandler para /documento directamente...")
    from handlers.documents import documento_command
    application.add_handler(CommandHandler("documento", documento_command))
    logger.info("CommandHandler para /documento registrado manualmente con éxito")
    handlers_registrados += 1
except Exception as e_fix:
    logger.error(f"Error al intentar registrar CommandHandler directo para /documento: {e_fix}")
    logger.error(traceback.format_exc())
```

Este cambio garantiza que el comando `/documento` siempre responda, incluso si hay problemas en los estados de conversación o en la estructura del handler.