### PR TITLE
Actualizar listado de comandos: /documento -> /evidencia

### DIFF
--- a/handlers/start.py
+++ b/handlers/start.py
@@ -27,7 +27,7 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         "*/pedidos* - Ver pedidos pendientes\n"
         "*/adelantos* - Ver adelantos vigentes\n"
         "*/almacen* - Gestionar almacén central\n"
-        "*/documento* - Cargar evidencia de pago de compras/ventas\n"
+        "*/evidencia* - Cargar evidencia de pago de compras/ventas\n"
         "*/ayuda* - Ver esta ayuda\n\n"
         "Para más información, consulta la documentación completa.",
         parse_mode="Markdown"


### PR DESCRIPTION
Este pull request actualiza el listado de comandos disponibles en el mensaje de ayuda para reflejar el cambio del comando `/documento` a `/evidencia`.

## Cambios realizados:
- Se ha actualizado el archivo `handlers/start.py` para mostrar el comando `/evidencia` en lugar de `/documento` en el mensaje que se muestra cuando se ejecuta el comando `/ayuda`.
- Este cambio complementa el PR #91 que implementa la funcionalidad del nuevo comando `/evidencia`.

El cambio asegura que la documentación del bot esté actualizada y sea consistente con la implementación actual de los comandos disponibles.