### PR TITLE
Corrección definitiva para el comando /evidencia con lista seleccionable

### DIFF
--- a/handlers/evidencias.py
+++ b/handlers/evidencias.py
@@ -133,6 +133,13 @@ async def cancelar(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     
     return ConversationHandler.END
 
+# Handler vacío asíncrono para el estado SUBIR_DOCUMENTO
+async def dummy_photo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    """Handler vacío para el estado SUBIR_DOCUMENTO, ya que el procesamiento real se hace en documents.py"""
+    # Este handler nunca se ejecutará realmente, pero se necesita para que el ConversationHandler acepte el estado
+    logger.info("Handler dummy_photo_handler ejecutado, esto no debería ocurrir normalmente.")
+    return ConversationHandler.END
+
 def register_evidencias_handlers(application):
     """Registra los handlers para el módulo de evidencias"""
     # Crear un handler de conversación específico para evidencias
@@ -141,7 +148,8 @@ def register_evidencias_handlers(application):
         states={
             SELECCIONAR_COMPRA: [MessageHandler(filters.TEXT & ~filters.COMMAND, seleccionar_compra)],
             # Agregar el estado SUBIR_DOCUMENTO para que el ConversationHandler lo reconozca
-            SUBIR_DOCUMENTO: [MessageHandler(filters.PHOTO, lambda update, context: None)],
+            # Usar una función async correcta, no una lambda que devuelve None
+            SUBIR_DOCUMENTO: [MessageHandler(filters.PHOTO, dummy_photo_handler)],
         },
         fallbacks=[CommandHandler("cancelar", cancelar)],
     )


### PR DESCRIPTION
## Corrección definitiva para el comando /evidencia con lista seleccionable

### Problemas identificados
Durante las pruebas del comando `/evidencia` se han detectado varios problemas:

1. **Error de estado desconocido**: `'seleccionar_compra' returned state 2 which is unknown to the ConversationHandler'`
2. **Formato incorrecto** en los elementos seleccionables del teclado
3. **Error de tipo**: `TypeError: object NoneType can't be used in 'await' expression`

### Soluciones implementadas

1. **Para el error de estado desconocido**:
   - Añadido el estado `SUBIR_DOCUMENTO` en el ConversationHandler de evidencias para que reconozca el estado correctamente

2. **Para el formato incorrecto**:
   - Corregido el formato para que sea exactamente `proveedor, tipo_cafe, fecha(sin hora), id`
   - Eliminado un apóstrofe que se estaba añadiendo incorrectamente en la fecha

3. **Para el error TypeError con NoneType**:
   - Reemplazada la función lambda (`lambda update, context: None`) con una función asíncrona apropiada
   - Implementado un handler vacío asíncrono (`dummy_photo_handler`) que devuelve un valor compatible con `await`
   - Esta solución corrige el error `TypeError: object NoneType can't be used in 'await' expression` que se producía debido a incompatibilidades con el entorno asíncrono

### Mejoras en la arquitectura del código
- El archivo `handlers/evidencias.py` ahora incluye un flujo de conversación bien definido
- El archivo `handlers/documents.py` ha sido refactorizado para permitir la reutilización desde otros comandos
- Se han añadido logs más detallados para facilitar la depuración

### Flujo de usuario mejorado
1. El usuario ejecuta `/evidencia`
2. Se le muestra un teclado con las últimas 10 compras en el formato correcto
3. El usuario selecciona una compra
4. Se extrae el ID y se inicia directamente el proceso de carga de evidencia
5. El usuario puede enviar la imagen, que se guarda correctamente en Google Drive

### Logs de pruebas anteriores vs actuales
**Logs con error:**
```
2025-05-20T01:23:20.086055+00:00 app[worker.1]: Traceback (most recent call last):
2025-05-20T01:23:20.086056+00:00 app[worker.1]:   File "/app/.heroku/python/lib/python3.10/site-packages/telegram/ext/_application.py", line 1298, in process_update
2025-05-20T01:23:20.086057+00:00 app[worker.1]:     await coroutine
2025-05-20T01:23:20.086059+00:00 app[worker.1]:   File "/app/.heroku/python/lib/python3.10/site-packages/telegram/ext/_handlers/basehandler.py", line 158, in handle_update
2025-05-20T01:23:20.086059+00:00 app[worker.1]:     return await self.callback(update, context)
2025-05-20T01:23:20.086059+00:00 app[worker.1]: TypeError: object NoneType can't be used in 'await' expression
```

**Logs esperados después de la corrección:**
```
app[worker.1]: === COMANDO /evidencia INICIADO por [username] (ID: [user_id]) ===
app[worker.1]: Obtenidos [N] registros de 'compras'
app[worker.1]: Usuario [user_id] seleccionó compra con ID: [compra_id]
app[worker.1]: Redirigiendo al flujo de /documento con tipo COMPRA y ID [compra_id]
app[worker.1]: Inicio directo de registro de documento para usuario [user_id]
```

Estos cambios garantizan que el comando `/evidencia` funcione correctamente, permitiendo a los usuarios seleccionar compras de una lista formateada según lo solicitado y completar el proceso de carga de evidencias sin errores.