### PR TITLE
Corrige error de parseo Markdown en comando /evidencia

### DIFF
--- a/handlers/evidencias.py
+++ b/handlers/evidencias.py
@@ -212,11 +212,10 @@ async def subir_documento(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     reply_markup = ReplyKeyboardMarkup(keyboard, one_time_keyboard=True, resize_keyboard=True)
     
     # Mostrar la imagen y solicitar confirmación
+    # MODIFICADO: Evitamos usar parse_mode="Markdown" para evitar errores de formato
     await update.message.reply_photo(
         photo=file_id,
-        caption=f"📝 *RESUMEN*\n\n{mensaje_confirmacion}\n\n"
-                f"¿Confirmar la carga de este documento?",
-        parse_mode="Markdown",
+        caption=f"📝 RESUMEN\n\n{mensaje_confirmacion}\n\n¿Confirmar la carga de este documento?",
         reply_markup=reply_markup
     )
     


### PR DESCRIPTION
## Corrección del error de parseo de Markdown en el comando /evidencia

### Problema identificado
Se ha detectado un error al procesar una foto en el handler de evidencias. El error específico es:

```
telegram.error.BadRequest: Can't parse entities: can't find end of the entity starting at byte offset 193
```

Este error ocurre porque estamos usando `parse_mode="Markdown"` con un texto que contiene caracteres especiales o formato que no es compatible con el parseo de Markdown en Telegram.

### Solución implementada

He realizado los siguientes cambios para resolver el problema:

1. **Eliminado el `parse_mode="Markdown"` de la función `subir_documento`**:
   - Al enviar una foto con un caption, ya no usamos Markdown para formatear el texto
   - Esto evita completamente los problemas de parseo de entidades

2. **Simplificado el formato del mensaje**:
   - Quitado los asteriscos (`*`) alrededor de "RESUMEN" que causaban el error
   - Mantenido el texto plano sin intentar usar formato Markdown

3. **Mantenido la misma estructura informativa**:
   - El mensaje sigue incluyendo toda la información relevante
   - La funcionalidad completa sigue intacta, solo cambia el formato

### Resultados esperados

Ahora, cuando el usuario sube una imagen como evidencia:
1. La imagen se procesa correctamente
2. Se muestra un resumen con todos los datos relevantes
3. No ocurre ningún error de parseo de entidades
4. El flujo continúa normalmente hasta completar la operación

Este cambio es simple pero efectivo para resolver el error actual sin afectar la funcionalidad general del comando `/evidencia`.