### PR TITLE
Hotfix: Mostrar todas las operaciones disponibles en comando /evidencia

### DIFF
--- a/handlers/evidencias.py
+++ b/handlers/evidencias.py
@@ -98,16 +98,16 @@ async def seleccionar_tipo(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         )
         return SELECCIONAR_TIPO
     
-    # Mostrar las operaciones recientes en un teclado seleccionable
+    # Mostrar las operaciones en un teclado seleccionable
     try:
         # Obtener datos según el tipo de operación seleccionado
         operaciones = get_all_data(operacion_plural)
         
         if operaciones:
             # Ordenar las operaciones por fecha (más recientes primero)
-            operaciones_recientes = sorted(operaciones, key=lambda x: x.get('fecha', ''), reverse=True)[:10]
+            operaciones_recientes = sorted(operaciones, key=lambda x: x.get('fecha', ''), reverse=True)
             
-            # Crear teclado con las operaciones
+            # Crear teclado con las operaciones - mostrar todas
             keyboard = []
             for operacion in operaciones_recientes:
                 operacion_id = operacion.get('id', 'Sin ID')
@@ -135,6 +135,7 @@ async def seleccionar_tipo(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             reply_markup = ReplyKeyboardMarkup(keyboard, one_time_keyboard=True, resize_keyboard=True)
             
             mensaje = f"📋 *SELECCIONA UNA {tipo_operacion} PARA ADJUNTAR EVIDENCIA*\n\n"
+            mensaje += f"Mostrando {len(operaciones_recientes)} {operacion_plural} disponibles"
             
             await update.message.reply_text(mensaje, parse_mode="Markdown", reply_markup=reply_markup)
             


### PR DESCRIPTION
## Descripción

Este hotfix mejora la funcionalidad del comando `/evidencia` para mostrar todas las operaciones disponibles, eliminando la limitación anterior que solo mostraba las 10 más recientes.

## Cambios realizados

1. **Eliminación del límite de operaciones**: Se ha eliminado la restricción de mostrar solo las 10 operaciones más recientes, ahora se muestran todas las operaciones disponibles.

2. **Mejora en la información mostrada**: Se ha añadido un contador que muestra cuántas operaciones están disponibles para seleccionar, proporcionando al usuario mejor visibilidad.

3. **Organización mejorada**: Las operaciones siguen ordenadas por fecha (más recientes primero) para facilitar la selección de las más recientes, pero ahora todas están disponibles si el usuario necesita acceder a operaciones anteriores.

## Justificación

La limitación anterior a 10 operaciones impedía a los usuarios registrar evidencias para operaciones antiguas, lo que causaba confusión y frustraba a los usuarios que necesitaban documentar operaciones históricas.

## Pruebas realizadas

- Se ha verificado que se muestran todos los registros disponibles en lugar de solo los 10 más recientes.
- Se ha comprobado que la navegación y selección de operaciones funciona correctamente con mayor cantidad de datos.
- Se han realizado pruebas de rendimiento para asegurar que con un número elevado de operaciones la interfaz sigue siendo funcional.

## Impacto en rendimiento

El impacto en rendimiento es mínimo incluso con grandes volúmenes de datos, ya que Telegram maneja bien los menús con muchas opciones. Sin embargo, para una mejor usabilidad, las operaciones siguen ordenadas por fecha, con las más recientes primero.
