### PR TITLE
Mejora del formato de visualización en comando /EVIDENCIA

### DIFF
--- a/PR_FORMATO_VISUALIZACION.md
+++ b/PR_FORMATO_VISUALIZACION.md
@@ -1,0 +1,24 @@
+# Mejora del formato de visualización en comando /EVIDENCIA
+
+## Problema
+Al ejecutar el comando `/EVIDENCIA` y seleccionar "Compras", la visualización de los registros no prioriza la información más relevante (proveedor, monto, tipo de café) en el formato actual.
+
+## Solución
+Se modificó el archivo `handlers/evidencias.py` para mejorar el formato de visualización en la selección de compras, mostrando la información en este orden:
+
+1. Proveedor
+2. Monto total (S/)
+3. Tipo de café
+
+## Cambios realizados
+- Reorganización del formato de visualización para mostrar en la primera línea: `[proveedor], S/ [monto], [tipo_cafe]`
+- El cambio se aplicó específicamente en la función `seleccionar_tipo` cuando se procesan las opciones de compra
+
+## Cómo probar
+1. Ejecutar el comando `/EVIDENCIA`
+2. Seleccionar "🛒 Compras"
+3. Verificar que ahora cada registro muestra un formato con esta estructura: `[proveedor], S/ [monto], [tipo_cafe], [fecha], [id]`
+4. Comparar con el formato anterior para confirmar la mejora
+
+## Impacto
+Este cambio facilita la identificación visual de las compras al mostrar primero los datos más relevantes, lo que mejora la experiencia del usuario sin afectar otras funcionalidades.

--- a/handlers/evidencias.py
+++ b/handlers/evidencias.py
@@ -113,10 +113,11 @@ async def seleccionar_tipo(update: Update, context: ContextTypes.DEFAULT_TYPE) -
                 operacion_id = operacion.get('id', 'Sin ID')
                 
                 if tipo_operacion == "COMPRA":
-                    # Para compras, mostrar proveedor y tipo de café
+                    # Para compras, mostrar proveedor, monto y tipo de café (NUEVO FORMATO)
                     proveedor = operacion.get('proveedor', 'Proveedor desconocido')
                     tipo_cafe = operacion.get('tipo_cafe', 'Tipo desconocido')
-                    descripcion = f"{proveedor}, {tipo_cafe}"
+                    total = operacion.get('preciototal', '0')
+                    descripcion = f"{proveedor}, S/ {total}, {tipo_cafe}"
                 else:  # VENTA
                     # Para ventas, mostrar cliente y producto
                     cliente = operacion.get('cliente', 'Cliente desconocido')


### PR DESCRIPTION
# Mejora del formato de visualización en comando /EVIDENCIA

## Problema
Al ejecutar el comando `/EVIDENCIA` y seleccionar "Compras", la visualización de los registros no prioriza la información más relevante (proveedor, monto, tipo de café) en el formato actual.

## Solución
Se modificó el archivo `handlers/evidencias.py` para mejorar el formato de visualización en la selección de compras, mostrando la información en este orden:

1. Proveedor
2. Monto total (S/)
3. Tipo de café

## Cambios realizados
- Reorganización del formato de visualización para mostrar en la primera línea: `[proveedor], S/ [monto], [tipo_cafe]`
- El cambio se aplicó específicamente en la función `seleccionar_tipo` cuando se procesan las opciones de compra

## Cómo probar
1. Ejecutar el comando `/EVIDENCIA`
2. Seleccionar "🛒 Compras"
3. Verificar que ahora cada registro muestra un formato con esta estructura: `[proveedor], S/ [monto], [tipo_cafe], [fecha], [id]`
4. Comparar con el formato anterior para confirmar la mejora

## Impacto
Este cambio facilita la identificación visual de las compras al mostrar primero los datos más relevantes, lo que mejora la experiencia del usuario sin afectar otras funcionalidades.