### PR TITLE
Fix: Corregir columnas desalineadas en el comando de adelantos

### DIFF
--- a/utils/sheets/constants.py
+++ b/utils/sheets/constants.py
@@ -34,7 +34,7 @@ HEADERS = {
     "gastos": ["fecha", "categoria", "monto", "descripcion", "registrado_por"],
     "ventas": ["fecha", "cliente", "tipo_cafe", "peso", "precio_kg", "total", "almacen_id", "notas", "registrado_por"],
     "pedidos": ["fecha", "cliente", "tipo_cafe", "cantidad", "precio_kg", "total", "estado", "fecha_entrega", "notas", "registrado_por"],
-    "adelantos": ["fecha", "hora", "cliente", "monto", "notas", "registrado_por"],
+    "adelantos": ["fecha", "hora", "proveedor", "monto", "saldo_restante", "notas", "registrado_por"],
     "almacen": ["id", "compra_id", "tipo_cafe_origen", "fecha", "cantidad", "fase_actual", "cantidad_actual", "notas", "fecha_actualizacion"],
     "documentos": ["id", "fecha", "tipo_operacion", "operacion_id", "archivo_id", "ruta_archivo", "drive_file_id", "drive_view_link", "registrado_por", "notas"]
 }


### PR DESCRIPTION
## Descripción
Este PR corrige un error en la función de adelantos donde las columnas no se guardaban correctamente en Google Sheets.

## Problema
Cuando se ejecuta el comando `/adelanto` y se envían los datos, las columnas en la hoja de cálculo no coinciden con los datos que se están guardando. En particular:

1. El código en `adelantos.py` estaba utilizando "proveedor" pero las cabeceras definidas en `constants.py` usaban "cliente".
2. Se guarda el campo "saldo_restante" pero no estaba definido en las cabeceras.

## Solución
Se actualizaron las cabeceras en `constants.py` para que coincidan con los campos que realmente se están utilizando en `adelantos.py`.

Ahora las cabeceras son:
```python
"adelantos": ["fecha", "hora", "proveedor", "monto", "saldo_restante", "notas", "registrado_por"]
```

## Pruebas
Se ha verificado que el error estaba en la definición de las cabeceras, lo que causaba que los datos se guardaran en columnas incorrectas.

## Capturas
En las imágenes proporcionadas se puede ver claramente que la columna "saldo_restante" se estaba guardando en la posición incorrecta.

## Impacto
Esta corrección evitará que los datos se guarden en columnas incorrectas y facilitará la correcta visualización de los registros de adelantos.