### PR TITLE
Fix: Limitar lista de operaciones a 10 en el comando /evidencia

### DIFF
--- a/handlers/evidencias.py
+++ b/handlers/evidencias.py
@@ -22,6 +22,9 @@ SELECCIONAR_TIPO, SELECCIONAR_OPERACION, SUBIR_DOCUMENTO, CONFIRMAR = range(4)
 # Datos temporales
 datos_evidencia = {}
 
+# Número máximo de operaciones a mostrar
+MAX_OPERACIONES = 10
+
 # Asegurar que existe el directorio de uploads
 if not os.path.exists(UPLOADS_FOLDER):
     os.makedirs(UPLOADS_FOLDER)
@@ -123,7 +126,10 @@ async def seleccionar_tipo(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             # Ordenar las operaciones por fecha (más recientes primero)
             operaciones_recientes = sorted(operaciones, key=lambda x: x.get('fecha', ''), reverse=True)
             
-            # Crear teclado con las operaciones - mostrar todas
+            # Limitar a las últimas 10 operaciones para el teclado
+            operaciones_recientes = operaciones_recientes[:MAX_OPERACIONES]
+            
+            # Crear teclado con las operaciones limitadas
             keyboard = []
             for operacion in operaciones_recientes:
                 operacion_id = operacion.get('id', 'Sin ID')
@@ -147,8 +153,14 @@ async def seleccionar_tipo(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             keyboard.append(["❌ Cancelar"])
             reply_markup = ReplyKeyboardMarkup(keyboard, one_time_keyboard=True, resize_keyboard=True)
             
+            total_operaciones = len(operaciones)
             mensaje = f"📋 *SELECCIONA UNA {tipo_operacion} PARA ADJUNTAR EVIDENCIA*\n\n"
-            mensaje += f"Mostrando {len(operaciones_recientes)} {operacion_plural} disponibles"
+            
+            # Indicar cuántas operaciones se están mostrando de un total
+            if total_operaciones > MAX_OPERACIONES:
+                mensaje += f"Mostrando las {MAX_OPERACIONES} {operacion_plural} más recientes de un total de {total_operaciones}"
+            else:
+                mensaje += f"Mostrando {total_operaciones} {operacion_plural} disponibles"
             
             await update.message.reply_text(mensaje, parse_mode="Markdown", reply_markup=reply_markup)
             


### PR DESCRIPTION
## Descripción
Este PR soluciona el problema reportado donde el comando `/evidencia` muestra todas las operaciones disponibles en lugar de limitar a solo las 10 más recientes.

## Cambios realizados
- Se agregó una constante `MAX_OPERACIONES = 10` para definir el número máximo de operaciones a mostrar
- Se modificó la función `seleccionar_tipo()` para limitar las operaciones mostradas en el teclado a las 10 más recientes
- Se actualizó el mensaje de información para indicar cuántas operaciones se están mostrando del total disponible

## Pruebas realizadas
Los logs mostraban que se estaban cargando 39 registros de compras, lo que hacía que el teclado de selección fuera muy grande. Con estos cambios, solo se mostrarán las 10 compras más recientes, facilitando la navegación y selección.

## Notas adicionales
El comando `/evidencias` ya estaba correctamente limitado a 10 registros, por lo que no fue necesario modificarlo.