### PR TITLE
Fix: Corregir generación de ID para capitalización

### DIFF
--- a/handlers/capitalizacion.py
+++ b/handlers/capitalizacion.py
@@ -164,8 +164,8 @@ async def notas_step(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     else:
         datos_capitalizacion[user_id]["notas"] = text
     
-    # Generar ID único
-    datos_capitalizacion[user_id]["id"] = generate_unique_id("CAP")
+    # Generar ID único con prefijo CAP
+    datos_capitalizacion[user_id]["id"] = generate_unique_id(6, "CAP-")
     
     # Obtener fecha y hora actual
     now = get_now_peru()


### PR DESCRIPTION
## Descripción

Este PR corrige un error en la función de capitalización que impedía la generación correcta de IDs únicos.

## Problema

Al intentar generar un ID único para la capitalización, se estaba pasando el prefijo "CAP" como primer argumento a la función `generate_unique_id`, pero esta función espera recibir primero la longitud (un número) y luego el prefijo.

El error específico era:
```
TypeError: 'str' object cannot be interpreted as an integer
```

Esto ocurría en la línea:
```python
datos_capitalizacion[user_id]["id"] = generate_unique_id("CAP")
```

## Solución

Se ha modificado la llamada a la función para pasar los parámetros en el orden correcto:

```python
datos_capitalizacion[user_id]["id"] = generate_unique_id(6, "CAP-")
```

Donde:
- `6` es la longitud del ID aleatorio (por defecto en la función)
- `"CAP-"` es el prefijo para identificar que es una capitalización

## Pruebas realizadas

Se ha verificado que con esta corrección, la función de capitalización funciona correctamente y genera IDs válidos con el formato `CAP-XXXXXX`.