### PR TITLE
Fix: Cambiar nombre de hoja a 'capitalizacion' (sin tilde)

### DIFF
--- a/HEROKU_DEPLOY.md
+++ b/HEROKU_DEPLOY.md
@@ -59,7 +59,7 @@ El bot utiliza múltiples hojas dentro del documento de Google Sheets para almac
 - **Adelantos**: Registro de adelantos a proveedores
 - **Pedidos**: Registro de pedidos de clientes
 - **Almacen**: Control de inventario
-- **Capitalización**: Registro de ingresos de capital
+- **capitalizacion**: Registro de ingresos de capital (sin tilde y en minúsculas)
 
 Si alguna de estas hojas no existe, el bot intentará crearla automáticamente la primera vez que se use la funcionalidad correspondiente.
 

--- a/handlers/capitalizacion.py
+++ b/handlers/capitalizacion.py
@@ -245,7 +245,7 @@ async def confirmar_step(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         ]
         
         # Registrar en Google Sheets
-        append_sheets("Capitalización", row)
+        append_sheets("capitalizacion", row)
         
         # Mensaje de confirmación
         await update.message.reply_text(


### PR DESCRIPTION
## Descripción

Este PR cambia el nombre de la hoja de Google Sheets para la funcionalidad de capitalización, pasando de "Capitalización" (con tilde) a "capitalizacion" (sin tilde y en minúsculas).

## Cambios realizados

1. Se modificó el archivo `handlers/capitalizacion.py` para cambiar la referencia a la hoja:
   ```python
   # Anterior
   append_sheets("Capitalización", row)
   
   # Nuevo
   append_sheets("capitalizacion", row)
   ```

2. Se actualizó la documentación en `HEROKU_DEPLOY.md` para reflejar el nombre correcto de la hoja:
   ```markdown
   - **capitalizacion**: Registro de ingresos de capital (sin tilde y en minúsculas)
   ```

## Razón del cambio

La estandarización de los nombres de hojas en Google Sheets sin caracteres especiales facilita:
- La integración con otros sistemas
- Evitar problemas de codificación
- Mantener coherencia con el resto del sistema

## Pruebas realizadas

Se ha verificado que con este nombre de hoja, la funcionalidad de capitalización trabaja correctamente y guarda los datos en la hoja "capitalizacion".