### PR TITLE
Fix: Añadir definición de hoja 'capitalizacion' en constantes

### DIFF
--- a/utils/sheets/constants.py
+++ b/utils/sheets/constants.py
@@ -36,5 +36,6 @@ HEADERS = {
     "pedidos": ["fecha", "cliente", "tipo_cafe", "cantidad", "precio_kg", "total", "estado", "fecha_entrega", "notas", "registrado_por"],
     "adelantos": ["fecha", "hora", "proveedor", "monto", "saldo_restante", "notas", "registrado_por"],
     "almacen": ["id", "compra_id", "tipo_cafe_origen", "fecha", "cantidad", "fase_actual", "cantidad_actual", "notas", "fecha_actualizacion"],
-    "documentos": ["id", "fecha", "tipo_operacion", "operacion_id", "archivo_id", "ruta_archivo", "drive_file_id", "drive_view_link", "registrado_por", "notas"]
+    "documentos": ["id", "fecha", "tipo_operacion", "operacion_id", "archivo_id", "ruta_archivo", "drive_file_id", "drive_view_link", "registrado_por", "notas"],
+    "capitalizacion": ["id", "fecha", "monto", "origen", "destino", "concepto", "registrado_por", "notas"]
 }


### PR DESCRIPTION
## Descripción

Este PR corrige el error que ocurre al intentar registrar una capitalización. El error se debe a que el nombre de la hoja "capitalizacion" no estaba definido en las constantes del sistema.

## Problema

Al intentar utilizar la función de capitalización, se produce el siguiente error:
```
2025-05-26T00:23:12.119082+00:00 app[worker.1]: 2025-05-26 00:23:12,118 - utils.sheets.core - ERROR - Nombre de hoja inválido: capitalizacion
```

Esto sucede porque en `utils/sheets/core.py`, existe una validación que verifica si el nombre de la hoja existe en las constantes definidas en `utils/sheets/constants.py`:

```python
def append_data(sheet_name, data):
    if sheet_name not in HEADERS:
        logger.error(f"Nombre de hoja inválido: {sheet_name}")
        raise ValueError(f"Nombre de hoja inválido: {sheet_name}")
```

## Solución

He añadido la definición de la hoja "capitalizacion" en el diccionario `HEADERS` en el archivo `utils/sheets/constants.py`:

```python
"capitalizacion": ["id", "fecha", "monto", "origen", "destino", "concepto", "registrado_por", "notas"]
```

Esta actualización permite que el sistema reconozca "capitalizacion" como una hoja válida y pueda registrar los datos correctamente.

## Pruebas realizadas

Con esta modificación, el sistema debería poder:
1. Reconocer la hoja "capitalizacion" como válida
2. Crear la hoja automáticamente si no existe
3. Registrar datos de capitalización correctamente en la hoja

La implementación sigue el mismo patrón que el resto de las hojas del sistema.