### PR TITLE
Fix: Corregir error en la llamada a get_filtered_data en el comando /evidencia

### DIFF
--- a/handlers/evidencias.py
+++ b/handlers/evidencias.py
@@ -368,8 +368,8 @@ async def seleccionar_operacion(update: Update, context: ContextTypes.DEFAULT_TY
         logger.info(f"Buscando detalles para {tipo_operacion} con ID: {operacion_id}")
         
         try:
-            # Obtener datos filtrados por ID
-            operacion_detalles = get_filtered_data(operacion_plural, "id", operacion_id)
+            # Obtener datos filtrados por ID - CORREGIDO: Ahora pasamos un diccionario de filtros
+            operacion_detalles = get_filtered_data(operacion_plural, {"id": operacion_id})
             
             if not operacion_detalles or len(operacion_detalles) == 0:
                 logger.error(f"No se encontraron detalles para {tipo_operacion} con ID: {operacion_id}")


### PR DESCRIPTION
## Descripción

Este pull request corrige un error que impide el funcionamiento del comando `/evidencia` después de implementar las funcionalidades faltantes. El problema fue detectado durante las pruebas en producción cuando se intentaba seleccionar una operación específica.

## Problema identificado

La función `get_filtered_data` en `utils/sheets/core.py` espera un diccionario como parámetro `filters`, pero se estaba llamando con dos strings separados:

```python
operacion_detalles = get_filtered_data(operacion_plural, "id", operacion_id)
```

Esto provocaba el siguiente error al intentar usar el comando `/evidencia`:

```
2025-05-26T01:27:40.575756+00:00 app[worker.1]: 2025-05-26 01:27:40,574 - utils.sheets.core - INFO - Obtenidos 1 registros de 'capitalizacion'
2025-05-26T01:27:40.575758+00:00 app[worker.1]: 2025-05-26 01:27:40,574 - handlers.evidencias - ERROR - Error al obtener detalles de la operación: 'str' object has no attribute 'items'
2025-05-26T01:27:40.575759+00:00 app[worker.1]: 2025-05-26 01:27:40,575 - handlers.evidencias - ERROR - Traceback (most recent call last):
2025-05-26T01:27:40.575759+00:00 app[worker.1]:   File "/app/handlers/evidencias.py", line 372, in seleccionar_operacion
2025-05-26T01:27:40.575760+00:00 app[worker.1]:     operacion_detalles = get_filtered_data(operacion_plural, "id", operacion_id)
2025-05-26T01:27:40.575760+00:00 app[worker.1]:   File "/app/utils/sheets/core.py", line 652, in get_filtered_data
2025-05-26T01:27:40.575761+00:00 app[worker.1]:     for key, value in filters.items():
2025-05-26T01:27:40.575762+00:00 app[worker.1]: AttributeError: 'str' object has no attribute 'items'
```

El error se produce porque `filters` se espera que sea un diccionario con el método `items()`, pero se le estaba pasando un string.

## Solución implementada

He corregido la llamada a la función `get_filtered_data` para pasar correctamente un diccionario:

```python
operacion_detalles = get_filtered_data(operacion_plural, {"id": operacion_id})
```

Esta modificación asegura que la función reciba los parámetros en el formato esperado y pueda realizar el filtrado correctamente.

## Pruebas realizadas

He probado la solución en los siguientes escenarios:

- Selección de diferentes tipos de operaciones (compras, ventas, adelantos, gastos, capitalización)
- Selección de operaciones específicas por ID
- Verificación de que los detalles de la operación se obtienen correctamente

Todos los escenarios funcionan correctamente y el comando `/evidencia` ahora opera sin errores.

## Impacto en el sistema

Esta corrección es de bajo impacto y no afecta a otras partes del código. Solo modifica una línea en el archivo `handlers/evidencias.py` para asegurar que la llamada a la función se realiza correctamente.

## Notas adicionales

Esta corrección complementa el pull request anterior (#133) donde se implementaron las funcionalidades faltantes del comando `/evidencia`. Ambos cambios son necesarios para que el comando funcione correctamente.