### PR TITLE
Fix: Corrige nombre de hoja para guardar evidencias

### DIFF
--- a/handlers/evidencias.py
+++ b/handlers/evidencias.py
@@ -731,12 +731,13 @@ async def confirmar(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
                 "drive_file_id": drive_file_id,
                 "drive_view_link": drive_view_link,
                 "descripcion": descripcion,
-                "registrado_por": registrado_por
+                "registrado_por": registrado_por,
+                "notas": ""  # Campo notas vacío por defecto
             }
             
-            # Guardar en la hoja de evidencias
+            # Guardar en la hoja de documentos (antes era evidencias)
             logger.info(f"Guardando evidencia en sheets: {datos_evidencia_sheets}")
-            append_sheets("evidencias", datos_evidencia_sheets)
+            append_sheets("documentos", datos_evidencia_sheets)
             
             # Mensaje de éxito con enlace si está disponible
             mensaje_exito = f"✅ *EVIDENCIA REGISTRADA EXITOSAMENTE*\n\n"


### PR DESCRIPTION
## Descripción
Este PR corrige un error que ocurría al guardar evidencias para la casuística de capitalización. El problema estaba en que se intentaba guardar los datos en una hoja llamada "evidencias" que no existe, y según las constantes definidas en `utils/sheets/constants.py`, el nombre correcto de la hoja es "documentos".

## Cambios realizados
1. Se ha cambiado la llamada a `append_sheets("evidencias", datos_evidencia_sheets)` por `append_sheets("documentos", datos_evidencia_sheets)` en la función `confirmar` del archivo `handlers/evidencias.py`.

2. Se agregó el campo "notas" con valor vacío al diccionario `datos_evidencia_sheets` para asegurar que todos los campos requeridos estén presentes al guardar en la hoja de documentos.

## Problema que soluciona
Soluciona el error:
```
2025-05-26T01:47:42.495137+00:00 app[worker.1]: 2025-05-26 01:47:42,495 - utils.sheets.core - ERROR - Nombre de hoja inválido: evidencias
```

Que ocurría al intentar guardar evidencias en una hoja que no existe.

## Evidencia
El error en el log mostraba:
```
2025-05-26T01:47:42.495166+00:00 app[worker.1]: 2025-05-26 01:47:42,495 - handlers.evidencias - ERROR - Error al guardar evidencia: Nombre de hoja inválido: evidencias
```

Y el último mensaje de error sugería:
```
2025-05-26T01:47:42.495541+00:00 app[worker.1]:  creo que la hoja se llama documentos
```

Después de verificar las constantes en `utils/sheets/constants.py`, confirmé que efectivamente la hoja se llama "documentos" y no "evidencias".

## Probado
La corrección ha sido verificada revisando las constantes definidas en el archivo de constantes de la aplicación, donde se puede ver que la hoja correcta se llama "documentos" y tiene la misma estructura que necesitamos para guardar las evidencias.