### PR TITLE
Fix: Soluciona error de parseo de entidades en compra_mixta

### DIFF
--- a/handlers/compra_mixta.py
+++ b/handlers/compra_mixta.py
@@ -814,8 +814,8 @@ async def mostrar_resumen(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         # Obtener los datos de la compra
         datos = datos_compra_mixta[user_id]
         
-        # Crear resumen
-        resumen = "📋 *RESUMEN DE COMPRA MIXTA*\n\n"
+        # Crear resumen con los datos pero sin usar caracteres especiales o formateo Markdown
+        resumen = "📋 RESUMEN DE COMPRA MIXTA\n\n"
         resumen += f"☕ Tipo de café: {datos.get('tipo_cafe', '')}\n"
         resumen += f"👨‍🌾 Proveedor: {datos.get('proveedor', '')}\n"
         resumen += f"📦 Cantidad: {formatear_numero(datos.get('cantidad', 0))} kg\n"
@@ -850,7 +850,6 @@ async def mostrar_resumen(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         if update.message:
             await update.message.reply_text(
                 resumen + "\n¿Confirmas esta compra?",
-                parse_mode="Markdown",
                 reply_markup=reply_markup
             )
         else:
@@ -858,7 +857,6 @@ async def mostrar_resumen(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             await context.bot.send_message(
                 chat_id=update.callback_query.message.chat_id,
                 text=resumen + "\n¿Confirmas esta compra?",
-                parse_mode="Markdown",
                 reply_markup=reply_markup
             )
         
@@ -963,8 +961,8 @@ async def confirmar_step(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
                 if result_compra:
                     logger.info(f"Compra mixta guardada exitosamente para usuario {user_id}")
                     
-                    # Mensaje de éxito
-                    mensaje_exito = "✅ *¡COMPRA MIXTA REGISTRADA EXITOSAMENTE!*\n\n"
+                    # Mensaje de éxito - sin usar Markdown para evitar errores de parseo
+                    mensaje_exito = "✅ ¡COMPRA MIXTA REGISTRADA EXITOSAMENTE!\n\n"
                     mensaje_exito += f"ID: {datos['id']}\n"
                     mensaje_exito += f"Proveedor: {datos['proveedor']}\n"
                     mensaje_exito += f"Total: {formatear_precio(datos['preciototal'])}\n\n"
@@ -985,7 +983,6 @@ async def confirmar_step(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
                     
                     await update.message.reply_text(
                         mensaje_exito,
-                        parse_mode="Markdown",
                         reply_markup=ReplyKeyboardRemove()
                     )
                 else:


### PR DESCRIPTION
Este PR soluciona el error específico de parseo de entidades que ocurre al final del proceso de compra_mixta.

## Problema detectado

El error mostrado es: "Can't parse entities: can't find end of the entity starting at byte offset 201", que ocurre cuando se intenta usar el formato Markdown en mensajes de Telegram y hay algún problema con la sintaxis.

## Cambios implementados

1. **Eliminación del formato Markdown en mensajes finales**:
   - He eliminado el parámetro `parse_mode="Markdown"` de los mensajes de confirmación y resumen
   - Reemplacé cualquier caracteres o sintaxis especial de Markdown que pudieran causar problemas de parseo

2. **Mejora en la presentación de mensajes**:
   - Mantenemos los emojis y el formato visual usando saltos de línea y espaciado normal
   - El mensaje sigue siendo claro y legible, pero sin riesgo de errores de parseo

## Cómo probar

1. Usar el comando `/compra_mixta` y completar todo el proceso
2. Verificar que al llegar al final (confirmación), no aparece el error de parseo
3. La compra debería registrarse correctamente en todas las hojas (compras, compras_mixtas, almacén)

Este PR se enfoca específicamente en resolver el error "Can't parse entities" que ocurre al finalizar el proceso.